### PR TITLE
[IMPROVEMENT]  Parameterized go version for golangci linter

### DIFF
--- a/.github/workflows/.golangci.tmpl.yaml
+++ b/.github/workflows/.golangci.tmpl.yaml
@@ -65,7 +65,7 @@ linters-settings:
     extra-rules: true
 
     # Select the Go version to target.
-    lang-version: "1.17"
+    lang-version: "{{.go_version}}"
 
   goimports:
     auto-fix: false
@@ -102,7 +102,7 @@ linters-settings:
     # https://staticcheck.io/docs/options#checks
     checks: ["all"]
     # Select the Go version to target.
-    go: "1.17"
+    go: "{{.go_version}}"
 
   whitespace:
     auto-fix: true

--- a/.github/workflows/golangci.yaml
+++ b/.github/workflows/golangci.yaml
@@ -6,6 +6,9 @@ on:
       main_branch:
         default: "main"
         type: string
+      go:
+        type: string
+        default: "1.17"
   
 jobs:
   golangci:
@@ -40,7 +43,7 @@ jobs:
           curl 'https://raw.githubusercontent.com/TykTechnologies/github-actions/main/.github/workflows/.golangci.tmpl.yaml' -o .golangci.yaml
       - name: Render template
         id: render_template
-        uses: chuhlomin/render-template@v1.5
+        uses: chuhlomin/render-template@v1.7
         with:
           template: .golangci.yaml
           result_path: .golangci.yaml
@@ -49,6 +52,7 @@ jobs:
             goimports: ''
             build_tags: []
             skip_dirs: []
+            go_version: ${{ inputs.go }}
       - name: Apply template
         run: |
           cp .golangci.yaml /tmp/.golangci.yaml
@@ -66,7 +70,7 @@ jobs:
           cp /tmp/.golangci.yaml .golangci.yaml
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: ${{ inputs.go }}
       - name: Fetch modules
         run: |
           go mod download


### PR DESCRIPTION
Golang version for golangci linter was fixed on Go 1.17.

This PR adds the capability of receive the go version thru input parameters and render it in the golangci template.
