### PR TITLE
Add checkout-pr composite action

### DIFF
--- a/.github/actions/checkout-pr/action.yml
+++ b/.github/actions/checkout-pr/action.yml
@@ -1,0 +1,25 @@
+name: 'Checkout PR'
+description: >-
+  Checkout the exact number of PR commits + 1 (base_ref).
+inputs:
+  jobname:
+    default: ${{ github.job }}
+runs:
+  using: "composite"
+  steps:
+    - name: 'PR commits + 1'
+      shell: bash
+      run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
+
+    - name: 'Checkout PR branch and all PR commits'
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.ref }}
+        fetch-depth: ${{ env.PR_FETCH_DEPTH }}
+        lfs: true
+
+    - name: 'Fetch the other branch with enough history for a common merge-base commit'
+      shell: bash
+      run: |
+        git fetch origin ${{ github.event.pull_request.base.ref }}
+        git log -n 1

--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 Collection of shared github actions which are used in our org. 
 
+## PR Checkout
+
+The checkout PR action will fetch only the commits that belong to the PR.
+This is required for various code analysis tooling, including sonarcloud.
+
+Example usage:
+
+```
+jobs:
+  golangci-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR
+        uses: TykTechnologies/github-actions/.github/actions/checkout-pr@main
+```
+
 ## OWASP scanner
 Example usage:
 


### PR DESCRIPTION
Added action to checkout the exact number of commits on the PR + 1 (base_ref). The checkout-pr action is a composite action to be included in individual workflows. It automatically enables lfs, even if the repository doesn't use it. It's in place since we will need to address tyk-analytics bindata.go/git history at some point, and it's required for correct reporting in sonarcloud, otherwise false positives have been common.

More context: https://github.com/actions/checkout/issues/552#issuecomment-1167086216
