### PR TITLE
Add godoc.yml

### DIFF
--- a/.github/workflows/godoc.yml
+++ b/.github/workflows/godoc.yml
@@ -1,0 +1,79 @@
+name: Print Go API changes
+
+on:
+  workflow_call:
+
+jobs:
+  test:
+    name: Detect Go API changes
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout GH actions
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+          repository: TykTechnologies/exp
+          ref: main
+          path: /tmp/exp
+
+      - name: Checkout repo
+        uses: ../actions/checkout-pr@main
+
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.20"
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          version: 3
+
+      - name: Put taskfiles into place
+        run: |
+          rsync --del -a /tmp/exp/.taskfiles/ ./.taskfiles/
+
+      - name: Set up comment author
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+
+      - name: Collect API docs
+        run: |
+          go mod tidy
+          task -t .taskfiles/godoc/Taskfile.yml > current.txt
+          git checkout -- .
+          git checkout ${{ github.base_ref }}
+          go mod tidy
+          rsync -a /tmp/.taskfiles/ .taskfiles/
+          task -t .taskfiles/godoc/Taskfile.yml > prev.txt
+
+      - name: Diff API docs
+        id: api-check
+        run: |
+          set +e
+          diff -u prev.txt current.txt > changes.txt
+          echo "diff-output<<EOF" >> $GITHUB_OUTPUT
+          cat changes.txt >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Find Comment
+        uses: peter-evans/find-comment@v2
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: API Changes
+
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            API Changes
+            ```diff
+            ${{ steps.api-check.outputs.diff-output || 'no api changes detected' }}
+            ```
+          edit-mode: replace

--- a/.github/workflows/godoc.yml
+++ b/.github/workflows/godoc.yml
@@ -18,7 +18,7 @@ jobs:
           path: .tmp/exp
 
       - name: Checkout repo
-        uses: ./.github/actions/checkout-pr@main
+        uses: TykTechnologies/github-actions/.github/actions/checkout-pr@main
 
       - name: Setup Go
         uses: actions/setup-go@v4

--- a/.github/workflows/godoc.yml
+++ b/.github/workflows/godoc.yml
@@ -18,7 +18,7 @@ jobs:
           path: /tmp/exp
 
       - name: Checkout repo
-        uses: ../actions/checkout-pr@main
+        uses: ./.github/actions/checkout-pr@main
 
       - name: Setup Go
         uses: actions/setup-go@v4

--- a/.github/workflows/godoc.yml
+++ b/.github/workflows/godoc.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 1
           repository: TykTechnologies/exp
           ref: main
-          path: .tmp/exp
+          path: exp
 
       - name: Checkout repo
         uses: TykTechnologies/github-actions/.github/actions/checkout-pr@main
@@ -32,7 +32,7 @@ jobs:
 
       - name: Put taskfiles into place
         run: |
-          rsync --del -a .tmp/exp/.taskfiles/ ./.taskfiles/
+          rsync --del -a exp/.taskfiles/ ./.taskfiles/
 
       - name: Set up comment author
         run: |
@@ -46,7 +46,7 @@ jobs:
           git checkout -- .
           git checkout ${{ github.base_ref }}
           go mod tidy
-          rsync -a .tmp/.taskfiles/ .taskfiles/
+          rsync -a exp/.taskfiles/ .taskfiles/
           task -t .taskfiles/godoc/Taskfile.yml > prev.txt
 
       - name: Diff API docs

--- a/.github/workflows/godoc.yml
+++ b/.github/workflows/godoc.yml
@@ -9,16 +9,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout GH actions
+      - name: Checkout repo
+        uses: TykTechnologies/github-actions/.github/actions/checkout-pr@main
+
+      - name: Checkout exp
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
           repository: TykTechnologies/exp
           ref: main
           path: exp
-
-      - name: Checkout repo
-        uses: TykTechnologies/github-actions/.github/actions/checkout-pr@main
 
       - name: Setup Go
         uses: actions/setup-go@v4

--- a/.github/workflows/godoc.yml
+++ b/.github/workflows/godoc.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 1
           repository: TykTechnologies/exp
           ref: main
-          path: /tmp/exp
+          path: .tmp/exp
 
       - name: Checkout repo
         uses: ./.github/actions/checkout-pr@main
@@ -32,7 +32,7 @@ jobs:
 
       - name: Put taskfiles into place
         run: |
-          rsync --del -a /tmp/exp/.taskfiles/ ./.taskfiles/
+          rsync --del -a .tmp/exp/.taskfiles/ ./.taskfiles/
 
       - name: Set up comment author
         run: |
@@ -46,7 +46,7 @@ jobs:
           git checkout -- .
           git checkout ${{ github.base_ref }}
           go mod tidy
-          rsync -a /tmp/.taskfiles/ .taskfiles/
+          rsync -a .tmp/.taskfiles/ .taskfiles/
           task -t .taskfiles/godoc/Taskfile.yml > prev.txt
 
       - name: Diff API docs

--- a/.github/workflows/godoc.yml
+++ b/.github/workflows/godoc.yml
@@ -30,10 +30,6 @@ jobs:
         with:
           version: 3
 
-      - name: Put taskfiles into place
-        run: |
-          rsync --del -a exp/.taskfiles/ ./.taskfiles/
-
       - name: Set up comment author
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
@@ -41,13 +37,16 @@ jobs:
 
       - name: Collect API docs
         run: |
+          cp ./exp/.taskfiles/godoc/Taskfile.yml ./Taskfile.godoc.yml
+
           go mod tidy
-          task -t .taskfiles/godoc/Taskfile.yml > current.txt
+          task -t Taskfile.godoc.yml > current.txt
+
           git checkout -- .
           git checkout ${{ github.base_ref }}
+
           go mod tidy
-          rsync -a exp/.taskfiles/ .taskfiles/
-          task -t .taskfiles/godoc/Taskfile.yml > prev.txt
+          task -t Taskfile.godoc.yml > prev.txt
 
       - name: Diff API docs
         id: api-check

--- a/README.md
+++ b/README.md
@@ -18,6 +18,20 @@ jobs:
         uses: TykTechnologies/github-actions/.github/actions/checkout-pr@main
 ```
 
+## Print Go API Changes
+
+For a PR, the action will print the changes in `go doc` output. This
+surfaces API changes (function removals, renames, additions), as well as
+comment changes.
+
+Example usage:
+
+```
+jobs:
+  godoc:
+    uses: TykTechnologies/github-actions/.github/workflows/godoc.yml@main
+```
+
 ## OWASP scanner
 Example usage:
 


### PR DESCRIPTION
This PR implements an API check. It runs `go doc` against the base ref and head ref of a PR, printing the detected API changes into a GitHub comment. This is similar to what the go team does to maintain backwards compatibility between go versions.

Reference: https://go.dev/blog/compat ("API Checking")