### PR TITLE
SYSE-274/Rework CI images tag policy

### DIFF
--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -103,7 +103,7 @@ jobs:
         with:
           format: 'cyclonedx'
           output: 'docker.sbom.json'
-          image-ref: '${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name}}:${{ github.sha }}'
+          image-ref: '${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name}}:sha-${{ github.sha }}'
           
       - name: Generate Docker SBOM
         uses: aquasecurity/trivy-action@master


### PR DESCRIPTION
Adding prefix for sha tag. Tags needs to change this way so clean policies on ECR repo can be applied based on prefixes like sha, pr, etc.