### PR TITLE
[TT-11825] Pin trivy action version

### DIFF
--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -88,7 +88,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1
 
       - name: Generate Source code SBOM
-        uses: aquasecurity/trivy-action@0.11.2
+        uses: aquasecurity/trivy-action@0.16.1
         with:
            scan-type: 'fs'
            format: 'cyclonedx'
@@ -96,7 +96,7 @@ jobs:
            image-ref: '.'
 
       - name: Generate Docker SBOM
-        uses: aquasecurity/trivy-action@0.11.2
+        uses: aquasecurity/trivy-action@0.16.1
         env:
           DOCKER_IMAGE: ${{ secrets.DOCKER_IMAGE }}
         if: env.DOCKER_IMAGE == null
@@ -106,7 +106,7 @@ jobs:
           image-ref: '${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name}}:sha-${{ github.sha }}'
           
       - name: Generate Docker SBOM
-        uses: aquasecurity/trivy-action@0.11.2
+        uses: aquasecurity/trivy-action@0.16.1
         env:
           DOCKER_IMAGE: ${{ secrets.DOCKER_IMAGE }}
         if: env.DOCKER_IMAGE


### PR DESCRIPTION
Update trivy action version to [v0.16.1](https://github.com/aquasecurity/trivy-action/releases/tag/0.16.1) which uses trivy version 0.48.1.

[v0.17.0](https://github.com/aquasecurity/trivy-action/releases/tag/0.17.0) is the next available action version, it uses trivy v0.49.0, which caused to change cycloneDX tools schema. 
https://github.com/aquasecurity/trivy/commit/fb36c4ed09efc3fc241d02713c4cc864b6c6a2c8