### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/ci-docker-tools.yml
+++ b/.github/workflows/ci-docker-tools.yml
@@ -45,15 +45,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: docker/setup-buildx-action@v2
-      - uses: docker/login-action@v2
+      - uses: actions/checkout@v4.2.1
+      - uses: docker/setup-buildx-action@v3.7.1
+      - uses: docker/login-action@v3.3.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: 'Build tykio/ci-tools:${{ matrix.tag }}'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6.9.0
         with:
           push: ${{ github.ref_name == 'main' || github.event_name == 'workflow_dispatch' }}
           pull: true
@@ -65,7 +65,7 @@ jobs:
       - run: docker image ls
 
       - name: 'Extract tykio/ci-tools:${{ matrix.tag }}'
-        uses: shrink/actions-docker-extract@v3
+        uses: shrink/actions-docker-extract@v3.0.1
         with:
           image: tykio/ci-tools:${{ matrix.tag }}
           path: /usr/local/bin/.

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -28,8 +28,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: arduino/setup-task@v1
+      - uses: actions/checkout@v4.2.1
+      - uses: arduino/setup-task@v2.0.0
         with:
           version: 3
 

--- a/.github/workflows/create-update-comment.yaml
+++ b/.github/workflows/create-update-comment.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Find Comment
-        uses: peter-evans/find-comment@v2
+        uses: peter-evans/find-comment@v3.1.0
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -29,7 +29,7 @@ jobs:
           body-includes: ${{ inputs.body-includes }}
 
       - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v3
+        uses: peter-evans/create-or-update-comment@v4.0.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/godoc.yml
+++ b/.github/workflows/godoc.yml
@@ -31,7 +31,7 @@ jobs:
           token: ${{ secrets.ORG_GH_TOKEN }}
 
       - name: Checkout exp
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.2.1
         with:
           fetch-depth: 1
           repository: TykTechnologies/exp
@@ -39,12 +39,12 @@ jobs:
           path: exp
 
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5.0.2
         with:
           go-version: ${{ inputs.go-version }}
 
       - name: Install Task
-        uses: arduino/setup-task@v1
+        uses: arduino/setup-task@v2.0.0
         with:
           version: 3
 
@@ -77,7 +77,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Find Comment
-        uses: peter-evans/find-comment@v2
+        uses: peter-evans/find-comment@v3.1.0
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -85,7 +85,7 @@ jobs:
           body-includes: API Changes
 
       - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v3
+        uses: peter-evans/create-or-update-comment@v4.0.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/golangci.yaml
+++ b/.github/workflows/golangci.yaml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git - checkout master
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.2.1
         with:
           ref: ${{ inputs.main_branch }}
           fetch-depth: 1
       - name: Git - checkout current ref
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
+        uses: actions/checkout@v4.2.1
+      - uses: actions/cache@v4.1.1
         with:
           # In order:
           # * Module download cache
@@ -43,7 +43,7 @@ jobs:
           curl 'https://raw.githubusercontent.com/TykTechnologies/github-actions/main/.github/workflows/.golangci.tmpl.yaml' -o .golangci.yaml
       - name: Render template
         id: render_template
-        uses: chuhlomin/render-template@v1.7
+        uses: chuhlomin/render-template@v1.10
         with:
           template: .golangci.yaml
           result_path: .golangci.yaml
@@ -68,7 +68,7 @@ jobs:
             git checkout $ref
           fi
           cp /tmp/.golangci.yaml .golangci.yaml
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5.0.2
         with:
           go-version: ${{ inputs.go }}
       - name: Fetch modules
@@ -86,13 +86,13 @@ jobs:
         run: |
           $(go env GOPATH)/bin/golangci-lint run --verbose --out-format 'checkstyle:golangci_lint.xml' --timeout=300s --new=false --new-from-rev= ./...
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4.4.3
         if: ${{ always() }}
         with:
           name: golangci-report
           path: "*xml"
           
-      - uses: reviewdog/action-setup@v1
+      - uses: reviewdog/action-setup@v1.3.0
         if: ${{ always() }}
         with:
           reviewdog_version: latest # Optional. [latest,nightly,v.X.Y.Z]

--- a/.github/workflows/gotest.yaml
+++ b/.github/workflows/gotest.yaml
@@ -19,25 +19,25 @@ jobs:
     name: Go Test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@v5.0.2
       with:
         go-version: ${{ inputs.go }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.2.1
     
     - name: Start Redis
       if: ${{ inputs.redis != '' }}
-      uses: supercharge/redis-github-action@1.2.0
+      uses: supercharge/redis-github-action@1.8.0
       with:
         redis-version: '${{ inputs.redis }}'
 
     - name: Start MongoDB
       if: ${{ inputs.mongo != '' }}
-      uses: supercharge/mongodb-github-action@1.2.0
+      uses: supercharge/mongodb-github-action@1.11.0
       with:
         mongodb-version: '${{ inputs.mongo }}'    
         
     - name: Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4.1.1
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -67,18 +67,18 @@ jobs:
             gotestsum --junitfile ${coveragefile}.xml --raw-command go test ${OPTS} --json -timeout 15m -coverprofile=${coveragefile}.cov ${pkg} ${tags}
         done
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4.4.3
       with:
         name: coverage
         path: "*cov"
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4.4.3
       if: ${{ always() }}
       with:
         name: junit
         path: "*xml"
     - name: Github report view
       if: ${{ always() }}
-      uses: phoenix-actions/test-reporting@v8
+      uses: phoenix-actions/test-reporting@v15
       with:
         name: Unit Test Results
         path: "*.xml"

--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4.2.1
+      - uses: actions/setup-go@v5.0.2
 
       - name: Govulncheck scan
         run: |

--- a/.github/workflows/nancy.yaml
+++ b/.github/workflows/nancy.yaml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.2.1
 
       - name: Set up Go 1.x in order to write go.list file
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5.0.2
         with:
           go-version: 1.17
 
@@ -36,6 +36,6 @@ jobs:
         working-directory: ./${{ inputs.dir }}
 
       - name: Nancy scan
-        uses: sonatype-nexus-community/nancy-github-action@main
+        uses: sonatype-nexus-community/nancy-github-action@v1.0.2
         with:
           goListFile: ${{ inputs.dir }}/go.list

--- a/.github/workflows/owasp.yaml
+++ b/.github/workflows/owasp.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: OWASP Zap
-        uses: zaproxy/action-full-scan@v0.4.0
+        uses: zaproxy/action-full-scan@v0.11.0
         with:
           target: ${{ inputs.target }}
           cmd_options: '-a'

--- a/.github/workflows/pr-agent.yaml
+++ b/.github/workflows/pr-agent.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: PR Agent action step
         id: pragent
-        uses: Codium-ai/pr-agent@main
+        uses: Codium-ai/pr-agent@v0.24
         env:
           OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-bot.yaml
+++ b/.github/workflows/release-bot.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Check for release command
         id: check_command
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7.0.1
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -29,7 +29,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.check_command.outputs.release_valid == 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.2.1
         with:
           fetch-depth: 0
 
@@ -135,7 +135,7 @@ jobs:
 
       - name: Comment on PR
         if: steps.check_command.outputs.release_valid == 'true' && always()
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7.0.1
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/sbom-dev.yaml
+++ b/.github/workflows/sbom-dev.yaml
@@ -28,7 +28,7 @@ jobs:
     steps:
       # Make sure we have some code to diff.
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.2.1
         with:
           fetch-depth: 50
 
@@ -64,14 +64,14 @@ jobs:
     if: contains(github.ref, 'release-') || contains(github.ref, 'master') || contains(github.base_ref, 'release-') || contains(github.base_ref, 'master') || needs.changedfiles.outputs.go || needs.changedfiles.outputs.npm || needs.changedfiles.outputs.ci || needs.changedfiles.outputs.docker || needs.changedfiles.outputs.github
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.2.1
         with:
           fetch-depth: 1
           token: ${{ secrets.ORG_GH_TOKEN }}
           submodules: true
           
       - name: Configure AWS credentials for use
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4.0.2
         env:
           DOCKER_IMAGE: ${{ secrets.DOCKER_IMAGE }}
         if: env.DOCKER_IMAGE == null
@@ -85,10 +85,10 @@ jobs:
           DOCKER_IMAGE: ${{ secrets.DOCKER_IMAGE }}
         if: env.DOCKER_IMAGE == null
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2.0.1
 
       - name: Generate Source code SBOM
-        uses: aquasecurity/trivy-action@0.20.0
+        uses: aquasecurity/trivy-action@0.27.0
         with:
           scan-type: 'fs'
           format: 'cyclonedx'
@@ -96,7 +96,7 @@ jobs:
           image-ref: '.'
 
       - name: Generate Docker SBOM
-        uses: aquasecurity/trivy-action@0.20.0
+        uses: aquasecurity/trivy-action@0.27.0
         env:
           DOCKER_IMAGE: ${{ secrets.DOCKER_IMAGE }}
         if: env.DOCKER_IMAGE == null
@@ -106,7 +106,7 @@ jobs:
           image-ref: '${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name}}:sha-${{ github.sha }}'
           
       - name: Generate Docker SBOM
-        uses: aquasecurity/trivy-action@0.20.0
+        uses: aquasecurity/trivy-action@0.27.0
         env:
           DOCKER_IMAGE: ${{ secrets.DOCKER_IMAGE }}
         if: env.DOCKER_IMAGE

--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -28,7 +28,7 @@ jobs:
     steps:
       # Make sure we have some code to diff.
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.2.1
         with:
           fetch-depth: 50
 
@@ -64,14 +64,14 @@ jobs:
     if: contains(github.ref, 'release-') || contains(github.ref, 'master') || contains(github.base_ref, 'release-') || contains(github.base_ref, 'master') || needs.changedfiles.outputs.go || needs.changedfiles.outputs.npm || needs.changedfiles.outputs.ci || needs.changedfiles.outputs.docker || needs.changedfiles.outputs.github
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.2.1
         with:
           fetch-depth: 1
           token: ${{ secrets.ORG_GH_TOKEN }}
           submodules: true
           
       - name: Configure AWS credentials for use
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4.0.2
         env:
           DOCKER_IMAGE: ${{ secrets.DOCKER_IMAGE }}
         if: env.DOCKER_IMAGE == null
@@ -85,10 +85,10 @@ jobs:
           DOCKER_IMAGE: ${{ secrets.DOCKER_IMAGE }}
         if: env.DOCKER_IMAGE == null
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2.0.1
 
       - name: Generate Source code SBOM
-        uses: aquasecurity/trivy-action@0.16.1
+        uses: aquasecurity/trivy-action@0.27.0
         with:
           scan-type: 'fs'
           format: 'cyclonedx'
@@ -96,7 +96,7 @@ jobs:
           image-ref: '.'
 
       - name: Generate Docker SBOM
-        uses: aquasecurity/trivy-action@0.16.1
+        uses: aquasecurity/trivy-action@0.27.0
         env:
           DOCKER_IMAGE: ${{ secrets.DOCKER_IMAGE }}
         if: env.DOCKER_IMAGE == null
@@ -106,7 +106,7 @@ jobs:
           image-ref: '${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name}}:sha-${{ github.sha }}'
           
       - name: Generate Docker SBOM
-        uses: aquasecurity/trivy-action@0.16.1
+        uses: aquasecurity/trivy-action@0.27.0
         env:
           DOCKER_IMAGE: ${{ secrets.DOCKER_IMAGE }}
         if: env.DOCKER_IMAGE

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.2.1
 
       - name: Semgrep scan
         id: scan
@@ -29,7 +29,7 @@ jobs:
     
       - name: Archive Semgrep report
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: semgrep-report.txt
           path: semgrep-report.txt

--- a/.github/workflows/sonarcloud.yaml
+++ b/.github/workflows/sonarcloud.yaml
@@ -17,17 +17,17 @@ jobs:
     name: Sonarcloud
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.2.1
         with:
           fetch-depth: 0
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4.1.8
         with:
           name: coverage
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4.1.8
         with:
           name: golangci-report
       - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@master
+        uses: sonarsource/sonarcloud-github-action@v3.1.0
         with:
           args: >
             -Dsonar.organization=tyktechnologies

--- a/.github/workflows/update-gh-actions.yml
+++ b/.github/workflows/update-gh-actions.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.1
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.ORG_GH_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.9.0](https://github.com/docker/build-push-action/releases/tag/v6.9.0)** on 2024-09-30T09:51:48Z
* **[chuhlomin/render-template](https://github.com/chuhlomin/render-template)** published a new release **[v1.10](https://github.com/chuhlomin/render-template/releases/tag/v1.10)** on 2024-04-21T01:42:53Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.1](https://github.com/actions/checkout/releases/tag/v4.2.1)** on 2024-10-07T16:44:53Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.1.1](https://github.com/actions/cache/releases/tag/v4.1.1)** on 2024-10-08T17:09:10Z
* **[Codium-ai/pr-agent](https://github.com/Codium-ai/pr-agent)** published a new release **[v0.24](https://github.com/Codium-ai/pr-agent/releases/tag/v0.24)** on 2024-09-03T14:48:11Z
* **[aquasecurity/trivy-action](https://github.com/aquasecurity/trivy-action)** published a new release **[0.27.0](https://github.com/aquasecurity/trivy-action/releases/tag/0.27.0)** on 2024-10-11T04:49:28Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.4.3](https://github.com/actions/upload-artifact/releases/tag/v4.4.3)** on 2024-10-09T17:17:34Z
* **[aws-actions/configure-aws-credentials](https://github.com/aws-actions/configure-aws-credentials)** published a new release **[v4.0.2](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v4.0.2)** on 2024-02-07T00:27:10Z
* **[actions/github-script](https://github.com/actions/github-script)** published a new release **[v7.0.1](https://github.com/actions/github-script/releases/tag/v7.0.1)** on 2023-11-17T22:21:53Z
* **[zaproxy/action-full-scan](https://github.com/zaproxy/action-full-scan)** published a new release **[v0.11.0](https://github.com/zaproxy/action-full-scan/releases/tag/v0.11.0)** on 2024-09-25T14:03:56Z
* **[sonarsource/sonarcloud-github-action](https://github.com/sonarsource/sonarcloud-github-action)** published a new release **[v3.1.0](https://github.com/SonarSource/sonarcloud-github-action/releases/tag/v3.1.0)** on 2024-10-04T08:06:39Z
* **[peter-evans/find-comment](https://github.com/peter-evans/find-comment)** published a new release **[v3.1.0](https://github.com/peter-evans/find-comment/releases/tag/v3.1.0)** on 2024-04-02T08:21:18Z
* **[sonatype-nexus-community/nancy-github-action](https://github.com/sonatype-nexus-community/nancy-github-action)** published a new release **[v1.0.2](https://github.com/sonatype-nexus-community/nancy-github-action/releases/tag/v1.0.2)** on 2021-02-19T20:17:39Z
* **[arduino/setup-task](https://github.com/arduino/setup-task)** published a new release **[v2.0.0](https://github.com/arduino/setup-task/releases/tag/v2.0.0)** on 2024-02-06T10:25:08Z
* **[shrink/actions-docker-extract](https://github.com/shrink/actions-docker-extract)** published a new release **[v3.0.1](https://github.com/shrink/actions-docker-extract/releases/tag/v3.0.1)** on 2024-09-06T20:28:58Z
* **[phoenix-actions/test-reporting](https://github.com/phoenix-actions/test-reporting)** published a new release **[v15](https://github.com/phoenix-actions/test-reporting/releases/tag/v15)** on 2024-05-05T21:20:11Z
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v4.1.8](https://github.com/actions/download-artifact/releases/tag/v4.1.8)** on 2024-07-05T15:12:41Z
* **[supercharge/mongodb-github-action](https://github.com/supercharge/mongodb-github-action)** published a new release **[1.11.0](https://github.com/supercharge/mongodb-github-action/releases/tag/1.11.0)** on 2024-05-22T03:28:32Z
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v3.7.1](https://github.com/docker/setup-buildx-action/releases/tag/v3.7.1)** on 2024-10-04T07:44:26Z
* **[supercharge/redis-github-action](https://github.com/supercharge/redis-github-action)** published a new release **[1.8.0](https://github.com/supercharge/redis-github-action/releases/tag/1.8.0)** on 2023-12-12T03:55:37Z
* **[aws-actions/amazon-ecr-login](https://github.com/aws-actions/amazon-ecr-login)** published a new release **[v2.0.1](https://github.com/aws-actions/amazon-ecr-login/releases/tag/v2.0.1)** on 2023-10-02T21:18:49Z
* **[peter-evans/create-or-update-comment](https://github.com/peter-evans/create-or-update-comment)** published a new release **[v4.0.0](https://github.com/peter-evans/create-or-update-comment/releases/tag/v4.0.0)** on 2024-01-25T11:47:51Z
* **[actions/setup-go](https://github.com/actions/setup-go)** published a new release **[v5.0.2](https://github.com/actions/setup-go/releases/tag/v5.0.2)** on 2024-07-10T13:51:42Z
* **[reviewdog/action-setup](https://github.com/reviewdog/action-setup)** published a new release **[v1.3.0](https://github.com/reviewdog/action-setup/releases/tag/v1.3.0)** on 2024-03-12T15:18:50Z
* **[docker/login-action](https://github.com/docker/login-action)** published a new release **[v3.3.0](https://github.com/docker/login-action/releases/tag/v3.3.0)** on 2024-07-22T09:07:15Z
