### PR TITLE
Add lefthook to ci tools

### DIFF
--- a/docker/tools/latest/Dockerfile
+++ b/docker/tools/latest/Dockerfile
@@ -16,6 +16,7 @@ RUN --mount=type=cache,mode=0755,target=/go/pkg/mod go install github.com/golang
 RUN --mount=type=cache,mode=0755,target=/go/pkg/mod go install github.com/fatih/faillint@latest
 RUN --mount=type=cache,mode=0755,target=/go/pkg/mod go install gotest.tools/gotestsum@latest
 RUN --mount=type=cache,mode=0755,target=/go/pkg/mod go install github.com/wadey/gocovmerge@latest
+RUN --mount=type=cache,mode=0755,target=/go/pkg/mod go install github.com/evilmartians/lefthook@latest
 
 ARG TASK_VERSION=v3.27.1
 RUN curl -sSL https://github.com/go-task/task/releases/download/${TASK_VERSION}/task_linux_amd64.tar.gz | tar -zxv


### PR DESCRIPTION
Adds lefthook to ci tools to avoid a `go install` in the CI execution path.