### PR TITLE
[TT-15019] Update base image to Go 1.24

### DIFF
--- a/docker/tools/latest/Dockerfile
+++ b/docker/tools/latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23 AS tools-build
+FROM golang:1.24 AS tools-build
 
 ENV CGO_ENABLED=0
 ENV GOBIN=/usr/local/bin


### PR DESCRIPTION
PR for: https://tyktech.atlassian.net/browse/TT-15019

This version bump is required because golangci-lint prints the following error:

```
Run golangci-lint run --out-format colored-line-number,checkstyle:golangci-lint-report.json \
level=info msg="golangci-lint has version v1.64.8 built with go1.23.7 from (unknown, modified: ?, mod sum: \"h1:y5TdeVidMtBGG32zgSC7ZXTFNHrsJkDnpO4ItB3Am+I=\") on (unknown)"
level=info msg="[config_reader] Config search paths: [./ /home/runner/work/tyk/tyk /home/runner/work/tyk /home/runner/work /home/runner /home /]"
level=info msg="[config_reader] Used config file .golangci.yml"
Error: can't load config: the Go language version (go1.23) used to build golangci-lint is lower than the targeted Go version (1.24.0)
Failed executing command with error: can't load config: the Go language version (go1.23) used to build golangci-lint is lower than the targeted Go version (1.24.0)
Error: Process completed with exit code 3.
```

Related PRs:
- https://github.com/TykTechnologies/golang-cross/pull/24
- https://github.com/TykTechnologies/tyk/pull/7265