### PR TITLE
[QA-1677] Add DB type env var in UI test action

### DIFF
--- a/.github/actions/tests/ui-tests/action.yaml
+++ b/.github/actions/tests/ui-tests/action.yaml
@@ -6,6 +6,10 @@ inputs:
     description: 'Markers to filter tests'
     required: false
     default: ${{ matrix.envfiles.uimarkers }}
+  db_type:
+    description: 'Database used in the environment'
+    required: false
+    default: ${{ matrix.envfiles.db }}
 runs:
   using: "composite"
   steps:
@@ -23,6 +27,7 @@ runs:
         GW_URL: 'https://localhost:8080/'
         NODE_TLS_REJECT_UNAUTHORIZED: 0
         UI_MARKERS: ${{ inputs.ui_markers && format('--grep {0}', inputs.ui_markers ) || '' }}
+        TYK_TEST_DB_TYPE: ${{ inputs.db_type }}
       run: |
         npm ci
         npx playwright install --with-deps chromium


### PR DESCRIPTION
Framework needs to know on what DB type tests are executed. This change will pass the type from pipeline matrix to test execution