### PR TITLE
[TT-17030] Migrate workflows from PAT to GitHub App token

### DIFF
--- a/.github/workflows/godoc.yml
+++ b/.github/workflows/godoc.yml
@@ -3,7 +3,9 @@ name: Print Go API changes
 on:
   workflow_call:
     secrets:
-      ORG_GH_TOKEN:
+      PROBE_APP_ID:
+        required: true
+      PROBE_APP_PRIVATE_KEY:
         required: true
     inputs:
       go-version:
@@ -19,16 +21,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - name: Use GitHub Token
         env:
-          TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+          TOKEN: ${{ steps.app-token.outputs.token }}
         run: >
           git config --global url."https://${TOKEN}@github.com".insteadOf "https://github.com"
 
       - name: Checkout repo
         uses: TykTechnologies/github-actions/.github/actions/checkout-pr@75796ad54ffce9f0036f036414f8c9fb3dc5c0e0  # main
         with:
-          token: ${{ secrets.ORG_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Checkout exp
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3

--- a/.github/workflows/nancy.yaml
+++ b/.github/workflows/nancy.yaml
@@ -7,7 +7,9 @@ on:
         required: false
         type: string
     secrets:
-      ORG_GH_TOKEN:
+      PROBE_APP_ID:
+        required: false
+      PROBE_APP_PRIVATE_KEY:
         required: false
 
 jobs:
@@ -16,6 +18,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
 
@@ -26,7 +36,7 @@ jobs:
 
       - name: Configure git access for Tyk's private Go modules
         env:
-          GITHUB_PAT: ${{ secrets.ORG_GH_TOKEN }}
+          GITHUB_PAT: ${{ steps.app-token.outputs.token }}
         run: |
           echo "https://$GITHUB_PAT:x-oauth-basic@github.com" >> ~/.git-credentials
           git config --global credential.helper store


### PR DESCRIPTION
## Summary
- Replace `ORG_GH_TOKEN` (PAT) with GitHub App token generation using `actions/create-github-app-token` in `godoc.yml` and `nancy.yaml`
- Update `workflow_call` secret declarations: replace `ORG_GH_TOKEN` with `PROBE_APP_ID` and `PROBE_APP_PRIVATE_KEY`
- Fix `git config insteadOf` patterns in both workflows to use the generated app token
- **Note:** Callers of these reusable workflows will need to be updated to pass `PROBE_APP_ID` and `PROBE_APP_PRIVATE_KEY` instead of `ORG_GH_TOKEN`

## Test plan
- [ ] Verify `PROBE_APP_ID` and `PROBE_APP_PRIVATE_KEY` secrets are configured at the org level
- [ ] Update caller workflows to pass the new secrets
- [ ] Test a PR that triggers the godoc workflow to confirm API change detection works
- [ ] Test the nancy scan workflow to confirm Go dependency scanning works

🤖 Generated with [Claude Code](https://claude.com/claude-code)