### PR TITLE
[TT-17030] Migrate remaining workflows from PAT to GitHub App token

### DIFF
--- a/.github/workflows/jira-lint.yaml
+++ b/.github/workflows/jira-lint.yaml
@@ -5,17 +5,27 @@ on:
     secrets:
       JIRA_TOKEN:
         required: true
-      ORG_GH_TOKEN:
+      PROBE_APP_ID:
+        required: true
+      PROBE_APP_PRIVATE_KEY:
         required: true
 
 jobs:
   jira-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: cyrus-za/jira-lint@68fe771c843a59c7c7020e6b98817897abecb44b  # master 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
+      - uses: cyrus-za/jira-lint@68fe771c843a59c7c7020e6b98817897abecb44b  # master
         name: jira-lint
         with:
-          github-token: ${{ secrets.ORG_GH_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           jira-token: ${{ secrets.JIRA_TOKEN }}
           jira-base-url: https://tyktech.atlassian.net/
           skip-branches: '^(release-[0-9.-]+(lts)?|master|main)$'

--- a/.github/workflows/sbom-dev.yaml
+++ b/.github/workflows/sbom-dev.yaml
@@ -12,7 +12,9 @@ on:
         required: true
       DEPDASH_KEY:
         required: true
-      ORG_GH_TOKEN:
+      PROBE_APP_ID:
+        required: true
+      PROBE_APP_PRIVATE_KEY:
         required: true
     
 jobs:
@@ -63,11 +65,19 @@ jobs:
     needs: changedfiles
     if: contains(github.ref, 'release-') || contains(github.ref, 'master') || contains(github.base_ref, 'release-') || contains(github.base_ref, 'master') || needs.changedfiles.outputs.go || needs.changedfiles.outputs.npm || needs.changedfiles.outputs.ci || needs.changedfiles.outputs.docker || needs.changedfiles.outputs.github
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
         with:
           fetch-depth: 1
-          token: ${{ secrets.ORG_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           submodules: true
           
       - name: Configure AWS credentials for use

--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -12,7 +12,9 @@ on:
         required: true
       DEPDASH_KEY:
         required: true
-      ORG_GH_TOKEN:
+      PROBE_APP_ID:
+        required: true
+      PROBE_APP_PRIVATE_KEY:
         required: true
     
 jobs:
@@ -64,11 +66,19 @@ jobs:
     needs: changedfiles
     if: false && (contains(github.ref, 'release-') || contains(github.ref, 'master') || contains(github.base_ref, 'release-') || contains(github.base_ref, 'master') || needs.changedfiles.outputs.go || needs.changedfiles.outputs.npm || needs.changedfiles.outputs.ci || needs.changedfiles.outputs.docker || needs.changedfiles.outputs.github)
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
         with:
           fetch-depth: 1
-          token: ${{ secrets.ORG_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           submodules: true
           
       - name: Configure AWS credentials for use


### PR DESCRIPTION
## Summary
- Replace `ORG_GH_TOKEN` (PAT) with GitHub App token generation using `actions/create-github-app-token` in remaining reusable workflow files
- Migrated files: `sbom-dev.yaml`, `sbom.yaml`, `jira-lint.yaml`
- Updated `secrets:` declarations in all three `workflow_call` workflows to accept `PROBE_APP_ID` and `PROBE_APP_PRIVATE_KEY` instead of `ORG_GH_TOKEN` (same pattern as `godoc.yml` and `nancy.yaml`)
- Each job gets its own `app-token` step that generates a token at runtime

**Important:** Callers of these reusable workflows will need to update their `secrets:` block to pass `PROBE_APP_ID` and `PROBE_APP_PRIVATE_KEY` instead of `ORG_GH_TOKEN`.

## Test plan
- [ ] Verify `sbom-dev.yaml` can checkout with submodules using the app token
- [ ] Verify `sbom.yaml` can checkout with submodules using the app token
- [ ] Verify `jira-lint.yaml` can access PR info using the app token
- [ ] Update all caller workflows to pass the new secrets
- [ ] Confirm `PROBE_APP_ID` and `PROBE_APP_PRIVATE_KEY` secrets are configured at the org level

🤖 Generated with [Claude Code](https://claude.com/claude-code)