### PR TITLE
[TT-17030] Replace ADMIN_PAT with GitHub App token in force-merge.yaml

### DIFF
--- a/.github/workflows/force-merge.yaml
+++ b/.github/workflows/force-merge.yaml
@@ -3,8 +3,11 @@ name: Force Merge PR (Reusable)
 on:
   workflow_call:
     secrets:
-      ADMIN_PAT:
-        description: 'Personal Access Token with repo scope from an admin'
+      PROBE_APP_ID:
+        description: 'GitHub App ID for generating tokens'
+        required: true
+      PROBE_APP_PRIVATE_KEY:
+        description: 'GitHub App private key for generating tokens'
         required: true
       SLACK_WEBHOOK_URL:
         description: 'Slack Webhook URL for notifications'
@@ -14,12 +17,20 @@ jobs:
   force_merge:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - name: Check and Merge Pull Request
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410  # v6
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
-          github-token: ${{ secrets.ADMIN_PAT }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const comment = context.payload.comment;
             const issue = context.payload.issue;


### PR DESCRIPTION
## Summary
- Migrate force-merge reusable workflow from `ADMIN_PAT` (PAT) to GitHub App tokens
- Replace `ADMIN_PAT` secret with `PROBE_APP_ID` and `PROBE_APP_PRIVATE_KEY`
- Add `actions/create-github-app-token` step to generate a token before the merge step
- The generated token is used as `github-token` in `actions/github-script` for merge operations

## Note
The GitHub App must have sufficient permissions (admin/bypass branch protection) for force-merge to work. Verify the app's installation permissions cover this use case.

## Test plan
- [ ] Verify force-merge still works by commenting `/force-merge <reason>` on a test PR
- [ ] Verify Slack notifications are still sent after force-merge
- [ ] Verify non-admin users are still rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)