### PR TITLE
[TT-17030] Fix git auth: use x-access-token prefix for GitHub App tokens

### DIFF
--- a/.github/workflows/godoc.yml
+++ b/.github/workflows/godoc.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           TOKEN: ${{ steps.app-token.outputs.token }}
         run: >
-          git config --global url."https://${TOKEN}@github.com".insteadOf "https://github.com"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
 
       - name: Checkout repo
         uses: TykTechnologies/github-actions/.github/actions/checkout-pr@75796ad54ffce9f0036f036414f8c9fb3dc5c0e0  # main

--- a/.github/workflows/nancy.yaml
+++ b/.github/workflows/nancy.yaml
@@ -38,9 +38,9 @@ jobs:
         env:
           GITHUB_PAT: ${{ steps.app-token.outputs.token }}
         run: |
-          echo "https://$GITHUB_PAT:x-oauth-basic@github.com" >> ~/.git-credentials
+          echo "https://x-access-token:$GITHUB_PAT@github.com" >> ~/.git-credentials
           git config --global credential.helper store
-          git config --global url."https://$GITHUB_PAT:x-oauth-basic@github.com".insteadOf "https://github.com"
+          git config --global url."https://x-access-token:${GITHUB_PAT}@github.com/".insteadOf "https://github.com/"
       - name: Write Go List
         run: go list -json -m all > go.list
         working-directory: ./${{ inputs.dir }}


### PR DESCRIPTION
## Summary
- Fix `git config insteadOf` pattern in `godoc.yml` and `nancy.yaml` to use `x-access-token:` prefix and trailing slashes
- The bare token pattern fails when `actions/checkout` has set up a credential helper; the `x-access-token:` prefix ensures the URL rewrite takes precedence
- Also fixes the legacy `x-oauth-basic` credential pattern in `nancy.yaml`

## Files changed
- `.github/workflows/godoc.yml` — 1 replacement
- `.github/workflows/nancy.yaml` — 2 replacements (insteadOf + git-credentials)

## Test plan
- [ ] Verify `godoc` workflow runs successfully with private Go module deps
- [ ] Verify `nancy` workflow can resolve private Go modules for scanning

🤖 Generated with [Claude Code](https://claude.com/claude-code)