### PR TITLE
fix(dep-guard): handle branches with no merge base

### DIFF
--- a/.github/workflows/dependency-guard.yml
+++ b/.github/workflows/dependency-guard.yml
@@ -29,7 +29,7 @@ jobs:
           BASE_REF: ${{ github.event.pull_request.base.ref || github.event.repository.default_branch }}
           EXTRA_PATHS: ${{ inputs.extra_paths }}
         run: |
-          git fetch origin "$BASE_REF" --depth=1
+          git fetch origin "$BASE_REF"
 
           # Default monitored paths
           PATHS=(
@@ -46,7 +46,17 @@ jobs:
             done
           fi
 
-          CHANGED=$(git diff --name-only "origin/$BASE_REF"...HEAD -- "${PATHS[@]}")
+          if git merge-base "origin/$BASE_REF" HEAD >/dev/null 2>&1; then
+            CHANGED=$(git diff --name-only "origin/$BASE_REF"...HEAD -- "${PATHS[@]}")
+          else
+            echo "::warning title=Dependency Guard::No merge base found between HEAD and origin/$BASE_REF. Falling back to HEAD~1 comparison."
+            if git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+              CHANGED=$(git diff --name-only HEAD~1 HEAD -- "${PATHS[@]}")
+            else
+              # single-commit branch: compare against the empty tree
+              CHANGED=$(git diff --name-only 4b825dc642cb6eb9a060e54bf899d15363d7aa90 HEAD -- "${PATHS[@]}")
+            fi
+          fi
 
           if [ -n "$CHANGED" ]; then
             echo "::error::Dependency files changed in this PR. A reviewer must verify the changes and add the '${{ inputs.label_name }}' label to unblock CI."

--- a/.github/workflows/dependency-guard.yml
+++ b/.github/workflows/dependency-guard.yml
@@ -52,9 +52,6 @@ jobs:
             echo "::warning title=Dependency Guard::No merge base found between HEAD and origin/$BASE_REF. Falling back to HEAD~1 comparison."
             if git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
               CHANGED=$(git diff --name-only HEAD~1 HEAD -- "${PATHS[@]}")
-            else
-              # single-commit branch: compare against the empty tree
-              CHANGED=$(git diff --name-only 4b825dc642cb6eb9a060e54bf899d15363d7aa90 HEAD -- "${PATHS[@]}")
             fi
           fi
 

--- a/.github/workflows/dependency-guard.yml
+++ b/.github/workflows/dependency-guard.yml
@@ -29,7 +29,7 @@ jobs:
           BASE_REF: ${{ github.event.pull_request.base.ref || github.event.repository.default_branch }}
           EXTRA_PATHS: ${{ inputs.extra_paths }}
         run: |
-          git fetch origin "$BASE_REF"
+          git fetch origin "$BASE_REF" --depth=1
 
           # Default monitored paths
           PATHS=(


### PR DESCRIPTION
## Summary

- Add merge-base check before the diff, with fallback to `HEAD~1 HEAD` comparison for orphan/diverged branches
- Guard against single-commit branches where `HEAD~1` does not exist

## Why

The workflow crashes with `fatal: no merge base` on orphan or diverged branches (e.g. `release-5.13.0`).


[TT-17163](https://tyktech.atlassian.net/browse/TT-17163)

[TT-17163]: https://tyktech.atlassian.net/browse/TT-17163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ