### PR TITLE
[TT-17218] Add a default branch mechanism in test-controller

### DIFF
--- a/.github/actions/tests/test-controller/action.yaml
+++ b/.github/actions/tests/test-controller/action.yaml
@@ -11,6 +11,10 @@ inputs:
   test_type:
     description: 'Type of test, e.g. api or ui'
     required: true
+  default_branch:
+    description: 'Branch to fall back to when base_ref has no config in the API'
+    required: false
+    default: 'master'
 outputs:
   envfiles:
     description: 'Environment files for the test'
@@ -33,10 +37,29 @@ runs:
         REPO_NAME: ${{ github.event.repository.name }}
         TEST_TYPE: ${{ inputs.test_type }}
         TRIGGER: ${{ github.event_name }}
+        DEFAULT_BRANCH: ${{ inputs.default_branch }}
       run: |
         set -eo pipefail
-        curl -s --retry 5 --retry-delay 10 --fail-with-body "http://tui.internal.dev.tyk.technology/v2/$VARIATION/$REPO_NAME/$BASE_REF/$TRIGGER/$TEST_TYPE.gho" | tee -a "$GITHUB_OUTPUT"
-        if ! [[ $VARIATION =~ prod ]] ;then  
+        BASE_URL="http://tui.internal.dev.tyk.technology/v2/$VARIATION/$REPO_NAME"
+        ENDPOINT="$TRIGGER/$TEST_TYPE.gho"
+
+        HTTP_CODE=$(curl -s --retry 2 --retry-delay 10 \
+          -w "%{http_code}" -o /tmp/tui_response.txt \
+          "$BASE_URL/$BASE_REF/$ENDPOINT")
+
+        if [ "$HTTP_CODE" = "404" ]; then
+          echo "::warning::No test config for branch '$BASE_REF', falling back to '$DEFAULT_BRANCH'"
+          curl -s --retry 2 --retry-delay 10 --fail-with-body \
+            "$BASE_URL/$DEFAULT_BRANCH/$ENDPOINT" | tee -a "$GITHUB_OUTPUT"
+        elif [ "$HTTP_CODE" != "200" ]; then
+          echo "API returned HTTP $HTTP_CODE for branch '$BASE_REF'" >&2
+          cat /tmp/tui_response.txt >&2
+          exit 1
+        else
+          cat /tmp/tui_response.txt | tee -a "$GITHUB_OUTPUT"
+        fi
+
+        if ! [[ $VARIATION =~ prod ]] ;then
           echo "::warning file=.github/workflows/release.yml,line=24,col=1,endColumn=8::Using non-prod variation"
           echo "### :warning: You are using VARIATION=${VARIATION} in test-controller-{{ .test }}" >> $GITHUB_STEP_SUMMARY
         fi


### PR DESCRIPTION
When a pipeline is triggered on a branch not explicitly configured in the tui.yml file in gromit, the API returns 404, causing the step and whole pipeline to fail.

This change introduces a two-attempt fallback mechanism:
Fetch config for the exact base_ref — capturing the HTTP status without failing
On 404, emit a warning annotation and retry against default_branch (defaults to master)
On any other non-200, fail as before.
A new optional input default_branch is added so callers can override the fallback target per-workflow if needed.