### PR TITLE
TT-17163: fix dependency-guard failure on branches with no merge base

### DIFF
--- a/.github/workflows/dependency-guard.yml
+++ b/.github/workflows/dependency-guard.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check for dependency changes
-        if: ${{ !contains(github.event.pull_request.labels.*.name, inputs.label_name) }}
+        if: ${{ github.event.pull_request && !contains(github.event.pull_request.labels.*.name, inputs.label_name) }}
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref || github.event.repository.default_branch }}
           EXTRA_PATHS: ${{ inputs.extra_paths }}
@@ -46,7 +46,12 @@ jobs:
             done
           fi
 
-          CHANGED=$(git diff --name-only "origin/$BASE_REF"...HEAD -- "${PATHS[@]}")
+          if git merge-base "origin/$BASE_REF" HEAD >/dev/null 2>&1; then
+            CHANGED=$(git diff --name-only "origin/$BASE_REF"...HEAD -- "${PATHS[@]}")
+          else
+            echo "::warning title=Dependency Guard::No merge base found between HEAD and origin/$BASE_REF. Falling back to direct tree comparison (two-dot diff)."
+            CHANGED=$(git diff --name-only "origin/$BASE_REF"..HEAD -- "${PATHS[@]}")
+          fi
 
           if [ -n "$CHANGED" ]; then
             echo "::error::Dependency files changed in this PR. A reviewer must verify the changes and add the '${{ inputs.label_name }}' label to unblock CI."


### PR DESCRIPTION
### Issue
https://tyktech.atlassian.net/browse/TT-17163

### Description
This PR resolves a bug in the reusable `dependency-guard` workflow where the pipeline crashes with `fatal: origin/master...HEAD: no merge base` on branches with rewritten history, orphan branches, or direct push/release events.

### The Issues Addressed
1. **Unnecessary Runs on Direct Pushes/Releases:** 
   * A dependency guard acts as a gatekeeper to prevent unapproved dependency changes from merging. However, on direct push events (e.g., release branch creations or tag pushes), there is no PR interface, meaning there is no way for a reviewer to add a bypass label. Running the guard here causes a permanent pipeline block.
   * This exact bug broke the `tyk-analytics-ui` pipeline during a direct release branch push (run #25502662240).
2. **Crash on legitimate orphan PRs:** 
   * Legitimate PRs with no common ancestor (merge base) with `master` would crash when using the three-dot diff (`...`).

### Proposed Changes
1. **Restrict Guard to Pull Requests (`if:` condition):**
   * Added `github.event.pull_request` to the step check so the dependency guard is skipped entirely on direct pushes, schedules, or release dispatches.
2. **Two-Dot Diff Fallback:**
   * When running on a PR that has no merge base, the workflow now securely falls back to a direct two-dot diff (`git diff origin/BASE_REF..HEAD`) comparing the trees directly. 
   * This covers the entire accumulative state of the branch and safely ensures no commits can bypass the dependency checks.