### PR TITLE
Use treeless partial clone in initial checkout.

### DIFF
--- a/.github/workflows/dependency-guard.yml
+++ b/.github/workflows/dependency-guard.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
         with:
+          filter: tree:0
           fetch-depth: 0
 
       - name: Check for dependency changes


### PR DESCRIPTION
A treeless clone should be enough for the git 
operations we use. It should speed up the initial clone, 
and since we don't need to fetch a lot of tree objects 
on the further operations in dependency guard, it should 
be faster in those subsequent operations too.

### How was this tested

- A test PR was opened on tyk-analytics ( the repo that takes the most time to clone) https://github.com/TykTechnologies/tyk-analytics/pull/5776

- The release workflow was manually changed to point to this branch to test. 
- Another commit that introduces a dependency change was pushed on the same PR.
- Dependency guard had run from this branch on the pull request trigger, and identified the dependency change and had failed as intended, and the entire operation was finished in under 10s. - - https://github.com/TykTechnologies/tyk-analytics/actions/runs/26999157958/job/79675391291?pr=5776