### PR TITLE
TT-17776: add reusable drift-check workflow for gromit-managed repos

### DIFF
--- a/.github/workflows/drift-check.yml
+++ b/.github/workflows/drift-check.yml
@@ -1,0 +1,77 @@
+name: Gromit Drift Check
+
+on:
+  workflow_call:
+    inputs:
+      label_name:
+        description: 'PR label that bypasses the drift check'
+        default: 'drift-override'
+        type: string
+
+jobs:
+  drift-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Break-glass bypass
+        if: ${{ contains(github.event.pull_request.labels.*.name, inputs.label_name) }}
+        run: |
+          echo "::warning title=Drift check bypassed::'${{ inputs.label_name }}' label present. This change bypasses gromit; backport it into gromit's templates or it will be overwritten by the next policy sync."
+          {
+            echo "## :rotating_light: Drift check bypassed"
+            echo ""
+            echo "The \`${{ inputs.label_name }}\` label is present on this PR."
+            echo "Backport this change into gromit's templates, otherwise the next \`policy sync\` will overwrite it."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Checkout
+        if: ${{ !contains(github.event.pull_request.labels.*.name, inputs.label_name) }}
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+
+      - name: Set up Go
+        if: ${{ !contains(github.event.pull_request.labels.*.name, inputs.label_name) }}
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
+        with:
+          go-version: "1.22"
+
+      - name: Build gromit from master
+        if: ${{ !contains(github.event.pull_request.labels.*.name, inputs.label_name) }}
+        run: go install github.com/TykTechnologies/gromit@master
+
+      - name: Check for drift from gromit
+        if: ${{ !contains(github.event.pull_request.labels.*.name, inputs.label_name) }}
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -o pipefail
+          export PATH="$PATH:$(go env GOPATH)/bin"
+
+          REPO=$(basename "${{ github.repository }}")
+
+          if ! out=$(gromit policy gen --repo "$REPO" --branch "$BASE_REF" . 2>&1); then
+            if echo "$out" | grep -q "unknown among"; then
+              echo "::notice title=Drift check skipped::Branch '$BASE_REF' of $REPO is not managed by gromit."
+              exit 0
+            fi
+            echo "$out"
+            exit 1
+          fi
+
+          git add -A
+          if ! gromit policy diff .; then
+            echo "::error title=Drift from gromit detected::Files in this PR differ from what gromit generates for $REPO/$BASE_REF. These files are managed by gromit; make this change in gromit's templates instead (https://github.com/TykTechnologies/gromit). For release emergencies, a repo admin can add the '${{ inputs.label_name }}' label to bypass this check."
+            {
+              echo "## :x: Drift from gromit detected"
+              echo ""
+              echo "Gromit-managed files in this PR differ from what gromit generates for \`$REPO\`/\`$BASE_REF\`."
+              echo ""
+              echo '```'
+              git --no-pager diff --staged --stat
+              echo '```'
+              echo ""
+              echo "Make this change in [gromit](https://github.com/TykTechnologies/gromit) instead. For release emergencies, a repo admin can add the \`${{ inputs.label_name }}\` label to bypass this check."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          echo "No drift detected: $REPO/$BASE_REF matches gromit."


### PR DESCRIPTION
## Jira Ticket

<!-- Paste the link to the Jira ticket below -->

[TT-17776](https://tyktech.atlassian.net/browse/TT-17776)

## Description
```
Change renders what gromit generates for the PR's base branch and fails if
the committed files differ (gromit policy gen + policy diff).
```

<!-- Briefly describe what this PR does and why. -->

## Type of Change

- [ ] Bug fix
- [x] New feature / action
- [ ] Refactor / improvement
- [ ] Documentation update
- [ ] CI/CD / workflow change
- [ ] Other (please describe):

## Changes Made

<!-- List the key changes introduced by this PR. -->

-
-

## Testing

<!-- Describe how you tested these changes. Include relevant workflow run links if applicable. -->

- [ ] Manually triggered the affected workflow(s) and verified expected behaviour
- [ ] Checked that existing workflows are not broken

## Checklist

- [ ] My changes follow the existing conventions in this repo
- [ ] I have updated relevant documentation (e.g. `README.md`, action `description` fields)
- [ ] For changed shell scripts (if applicable): I ran `shellcheck`, used an appropriate shebang and error handling, and preserved required executable permissions
- [ ] For changed actions/scripts (if applicable): I added or updated validation, tests, or clear manual verification steps
- [ ] For changed JavaScript files (if applicable): I ran the relevant tests and linting/formatting checks
- [ ] For changed Python files (if applicable): I ran the relevant tests and linting/formatting checks
- [ ] For Dockerfile changes (if applicable): I reviewed the base image, build context, image size, and runtime security
- [ ] For changed actions (if applicable): I updated the `action.yml` interface, defaults, outputs, and examples as needed
- [ ] I reviewed security implications, including least-privilege permissions and safe handling of inputs, secrets, and tokens (if applicable)
- [ ] For workflow changes (if applicable): I reviewed triggers, permissions, concurrency, and fork safety
- [ ] I have assigned a reviewer


[TT-17776]: https://tyktech.atlassian.net/browse/TT-17776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ