### PR TITLE
Docs changes workflow

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -50,19 +50,16 @@ jobs:
     outputs:
       docs_affected: ${{ steps.match.outputs.docs_affected }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-        with:
-          fetch-depth: 0
-
+      # No checkout: the PR files API is much cheaper than a full-history
+      # clone on large repos, and returns exactly the PR's own changes.
       - name: Match changed files against docs paths
         id: match
         env:
+          GH_TOKEN: ${{ github.token }}
           DOCS_PATHS: ${{ inputs.docs_paths }}
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           affected=false
-          changed=$(git diff --name-only "origin/${BASE_REF}...HEAD")
+          changed=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq '.[].filename')
           while IFS= read -r file; do
             [ -z "$file" ] && continue
             while IFS= read -r pat; do
@@ -323,6 +320,6 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PM_TEAM: ${{ inputs.pm_team }}
         run: |
-          gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers" \
-            -f "team_reviewers[]=$PM_TEAM" \
+          jq -n --arg team "$PM_TEAM" '{team_reviewers: [$team]}' \
+            | gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers" --input - \
             || echo "::warning::Could not request review from team '$PM_TEAM' — check the slug and that the PROBE App can write PRs in this repo"

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,0 +1,328 @@
+# yamllint disable rule:line-length
+---
+name: Docs preview
+
+# Renders the generated-docs diff (config docs, OAS/x-tyk-gateway, swagger)
+# for a PR in a source repo, posts it as a sticky PR comment, and requests
+# an ADVISORY review from a PM team. Never a required check.
+#
+# Generation steps mirror the tyk-docs sync:
+# https://github.com/TykTechnologies/exp/blob/main/.github/workflows/tyk-docs.yml
+# Keep them in sync until they are factored into shared composite actions.
+
+on:
+  workflow_call:
+    inputs:
+      component:
+        description: 'Generator set to run: gateway, dashboard, pump, mdcb or portal'
+        required: true
+        type: string
+      docs_paths:
+        description: 'Newline-separated globs of doc-bearing paths; the workflow no-ops unless the PR touches one'
+        required: true
+        type: string
+      pm_team:
+        description: 'GitHub team slug to request as advisory reviewer (empty = comment only)'
+        required: false
+        default: ''
+        type: string
+      comment_marker:
+        description: 'Hidden marker identifying the sticky PR comment'
+        required: false
+        default: '<!-- docs-preview -->'
+        type: string
+    secrets:
+      PROBE_APP_ID:
+        required: true
+      PROBE_APP_PRIVATE_KEY:
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  detect:
+    name: Detect docs-bearing changes
+    # Fork PRs: secrets are unavailable and the config generator needs remote branch names.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    outputs:
+      docs_affected: ${{ steps.match.outputs.docs_affected }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Match changed files against docs paths
+        id: match
+        env:
+          DOCS_PATHS: ${{ inputs.docs_paths }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          affected=false
+          changed=$(git diff --name-only "origin/${BASE_REF}...HEAD")
+          while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            while IFS= read -r pat; do
+              [ -z "$pat" ] && continue
+              # bash [[ == ]] pattern matching: * matches across '/', so ** and * behave the same here
+              if [[ "$file" == $pat ]]; then
+                echo "docs-bearing change: $file (pattern: $pat)"
+                affected=true
+                break 2
+              fi
+            done <<< "$DOCS_PATHS"
+          done <<< "$changed"
+          echo "docs_affected=$affected" >> "$GITHUB_OUTPUT"
+
+  preview:
+    name: Generate docs preview
+    needs: [detect]
+    if: needs.detect.outputs.docs_affected == 'true'
+    runs-on: ubuntu-latest
+    env:
+      BASE_REF: ${{ github.event.pull_request.base.ref }}
+      HEAD_REF: ${{ github.event.pull_request.head.ref }}
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
+      - name: Checkout head
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: head
+          fetch-depth: 1
+
+      - name: Checkout base
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          path: base
+          fetch-depth: 1
+
+      - name: Prepare output directories
+        run: mkdir -p out-base out-head
+
+      - name: Set up Go
+        if: inputs.component == 'gateway'
+        uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed  # v5.1.0
+        with:
+          go-version: '1.21'
+
+      - name: Checkout exp (schema-gen + cleanup script)
+        if: inputs.component == 'gateway'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          repository: TykTechnologies/exp
+          path: exp
+          fetch-depth: 1
+
+      - name: Install schema-gen
+        if: inputs.component == 'gateway'
+        run: cd exp/cmd/schema-gen && GOBIN=/usr/local/bin go install .
+
+      - name: Generate x-tyk-gateway docs (base and head)
+        if: inputs.component == 'gateway'
+        run: |
+          for side in base head; do
+            (
+              cd "$side/apidef/oas"
+              schema-gen extract -o - | schema-gen markdown -i - \
+                --root XTykAPIGateway \
+                --skip "OldOAS,APIDef,OAS,TykExtensionConfigParams,ServerRegenerationConfig" \
+                --title "## Tyk vendor extension reference" \
+                --replace "tyktime.ReadableDuration=string,model.ObjectID=string,apidef.MiddlewareDriver=string,apidef.IdExtractorSource=string,apidef.IdExtractorType=string,apidef.RequestInputType=string,apidef.AuthTypeEnum=string,[]osin.AuthorizeRequestType=[]string" \
+                --heading-format "### **%s**" \
+                --trim "Tyk classic API definition" \
+                -o "$GITHUB_WORKSPACE/out-$side/x-tyk-gateway.mdx"
+            )
+            (
+              cd exp
+              python3 scripts/remove-oas-dublicates/index.py --input-file "$GITHUB_WORKSPACE/out-$side/x-tyk-gateway.mdx"
+            )
+          done
+
+      - name: Generate gateway swagger (base and head)
+        if: inputs.component == 'gateway'
+        run: |
+          massage() {
+            cp "$1" ./swagger-modified.yml
+            sed -i "s|'https://raw.githubusercontent.com/TykTechnologies/tyk/refs/heads/master/apidef/oas/schema/3.0.json'|'#/components/schemas/OpenAPI3Schema'|g" ./swagger-modified.yml
+            sed -i "s|https://raw.githubusercontent.com/TykTechnologies/tyk/refs/heads/master/apidef/oas/schema/3.0.json|'#/components/schemas/OpenAPI3Schema'|g" ./swagger-modified.yml
+            awk '
+              {print}
+              /schemas:/ && !done {
+                print "    OpenAPI3Schema:"
+                print "      type: object"
+                print "      additionalProperties: true"
+                done=1
+              }
+            ' ./swagger-modified.yml > "$2"
+          }
+          for side in base head; do
+            massage "$side/swagger.yml" "out-$side/gateway-swagger.yml"
+          done
+
+      - name: Generate dashboard docs (base and head)
+        if: inputs.component == 'dashboard'
+        run: |
+          massage() {
+            cp "$1" ./swagger-modified.yml
+            sed -i "s|'https://raw.githubusercontent.com/TykTechnologies/tyk/refs/heads/master/apidef/oas/schema/3.0.json'|'#/components/schemas/OpenAPI3Schema'|g" ./swagger-modified.yml
+            sed -i "s|https://raw.githubusercontent.com/TykTechnologies/tyk/refs/heads/master/apidef/oas/schema/3.0.json|'#/components/schemas/OpenAPI3Schema'|g" ./swagger-modified.yml
+            awk '
+              {print}
+              /schemas:/ && !done {
+                print "    OpenAPI3Schema:"
+                print "      type: object"
+                print "      additionalProperties: true"
+                done=1
+              }
+            ' ./swagger-modified.yml > "$2"
+          }
+          for side in base head; do
+            massage "$side/swagger.yml" "out-$side/dashboard-swagger.yml"
+            cp "$side/swagger-admin.yml" "out-$side/dashboard-admin-swagger.yml"
+            cp "$side/docs/opa/opa-rules.md" "out-$side/opa-rules.mdx"
+          done
+
+      - name: Generate MDCB swagger (base and head)
+        if: inputs.component == 'mdcb'
+        run: |
+          for side in base head; do
+            cp "$side/swagger.yml" "out-$side/mdcb-swagger.yml"
+          done
+
+      - name: Generate portal swagger (base and head)
+        if: inputs.component == 'portal'
+        run: |
+          for side in base head; do
+            cp "$side/docs/api/enterprise-developer-portal-swagger.yaml" "out-$side/enterprise-developer-portal-swagger.yaml"
+          done
+
+      - name: Checkout config info generator
+        if: contains(fromJSON('["gateway","dashboard","pump","mdcb"]'), inputs.component)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          repository: TykTechnologies/tyk-config-info-generator
+          token: ${{ steps.app-token.outputs.token }}
+          path: tyk-config-info-generator
+          ref: main
+
+      - name: Generate config docs (base and head)
+        if: contains(fromJSON('["gateway","dashboard","pump","mdcb"]'), inputs.component)
+        working-directory: ./tyk-config-info-generator/src
+        run: |
+          repo="${{ inputs.component }}"
+          for side in base head; do
+            if [ "$side" = "base" ]; then branch="$BASE_REF"; else branch="$HEAD_REF"; fi
+            sudo TOKEN=${{ steps.app-token.outputs.token }} node app.js "$repo:$branch"
+            cp "/node/home/tyk-config-info-generator/info/$branch/$repo.md" "$GITHUB_WORKSPACE/out-$side/$repo-config.mdx"
+          done
+
+      - name: Diff rendered docs
+        id: diff
+        run: |
+          set +e
+          diff -ruN out-base out-head > docs.diff
+          rc=$?
+          set -e
+          if [ "$rc" -gt 1 ]; then
+            echo "diff failed with exit code $rc" >&2
+            exit "$rc"
+          fi
+          if [ "$rc" -eq 1 ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+          wc -c docs.diff
+
+      - name: Upload full diff as artifact
+        if: steps.diff.outputs.changed == 'true'
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
+        with:
+          name: docs-preview-diff
+          path: docs.diff
+
+      - name: Build comment body
+        env:
+          MARKER: ${{ inputs.comment_marker }}
+          PM_TEAM: ${{ inputs.pm_team }}
+          COMPONENT: ${{ inputs.component }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          CHANGED: ${{ steps.diff.outputs.changed }}
+        run: |
+          if [ "$CHANGED" != "true" ]; then
+            {
+              echo "$MARKER"
+              echo "## 📚 Documentation preview"
+              echo
+              echo "No documentation impact — the latest changes do not alter generated docs."
+            } > comment-body.md
+            exit 0
+          fi
+          limit=60000
+          size=$(wc -c < docs.diff)
+          {
+            echo "$MARKER"
+            echo "## 📚 Documentation preview"
+            echo
+            echo "This PR changes generated documentation (component: \`$COMPONENT\`)."
+            if [ -n "$PM_TEAM" ]; then
+              echo
+              echo "cc @TykTechnologies/$PM_TEAM — advisory review requested; this does **not** block merging."
+            fi
+            echo
+            echo '<details><summary>Rendered docs diff</summary>'
+            echo
+            echo '````diff'
+            head -c "$limit" docs.diff
+            echo
+            echo '````'
+            echo
+            echo '</details>'
+            if [ "$size" -gt "$limit" ]; then
+              echo
+              echo "_Diff truncated (${size} bytes total). Full diff: \`docs-preview-diff\` artifact on the [workflow run]($RUN_URL)._"
+            fi
+          } > comment-body.md
+
+      - name: Find existing preview comment
+        id: fc
+        uses: peter-evans/find-comment@a54c31d7fa095754bfef525c0c8e5e5674c4b4b1  # v2
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body-includes: ${{ inputs.comment_marker }}
+
+      # Post when there is a docs diff; when there is none, only update an
+      # existing comment (a PR that never had docs impact stays silent).
+      - name: Create or update preview comment
+        if: steps.diff.outputs.changed == 'true' || steps.fc.outputs.comment-id != ''
+        uses: peter-evans/create-or-update-comment@23ff15729ef2fc348714a3bb66d2f655ca9066f2  # v3
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-path: comment-body.md
+          edit-mode: replace
+
+      # Advisory only, requested once per PR: on the first push that produces
+      # a docs diff (no pre-existing sticky comment). Uses the App token —
+      # GITHUB_TOKEN cannot request org team reviews.
+      - name: Request PM team review (advisory)
+        if: steps.diff.outputs.changed == 'true' && steps.fc.outputs.comment-id == '' && inputs.pm_team != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PM_TEAM: ${{ inputs.pm_team }}
+        run: |
+          gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers" \
+            -f "team_reviewers[]=$PM_TEAM" \
+            || echo "::warning::Could not request review from team '$PM_TEAM' — check the slug and that the PROBE App can write PRs in this repo"

--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ Adoption: gateway, dashboard, reuse in shared CI workflows.
 
 Source: [/.github/actions/checkout-pr/action.yml](/.github/actions/checkout-pr/action.yml)
 
-## Github to slack
+## Upload Failed Job Logs
 
-Maps github email with slack user, based on a key value map. Maps needs to be mantained manually.
+On workflow job failure, fetch and send relevant logs with branch information to an external API
 
-Source: [/.github/actions/github-to-slack/action.yaml](/.github/actions/github-to-slack/action.yaml)
+Source: [/.github/actions/gh-logs-analyser/action.yaml](/.github/actions/gh-logs-analyser/action.yaml)
 
 ## Calculate tests tags
 
@@ -43,6 +43,12 @@ Calculates corresponding CI image tags based on github events for a group of tyk
 Source: [/.github/actions/latest-versions/action.yaml](/.github/actions/latest-versions/action.yaml)
 
 # Reusable workflows
+
+## Branch Suggestion for PRs
+
+Undocumented action.
+
+Source: [/.github/workflows/branch-suggestion.yml](/.github/workflows/branch-suggestion.yml)
 
 ## CI tooling
 
@@ -107,11 +113,94 @@ Adoption: Internal use for PR workflows on the repository.
 
 Source: [/.github/workflows/ci-lint.yml](/.github/workflows/ci-lint.yml)
 
+## CI Tests
+
+Undocumented action.
+
+Source: [/.github/workflows/ci-test.yml](/.github/workflows/ci-test.yml)
+
 ## Create or update a GitHub comment
 
 Undocumented action.
 
 Source: [/.github/workflows/create-update-comment.yaml](/.github/workflows/create-update-comment.yaml)
+
+## Dependency Change Guard
+
+Undocumented action.
+
+Source: [/.github/workflows/dependency-guard.yml](/.github/workflows/dependency-guard.yml)
+
+## Docs preview
+
+Renders the generated-documentation diff (config docs, OAS/x-tyk-gateway,
+swagger) for a PR in a source repo, posts it as a sticky PR comment, and
+requests an **advisory** review from a PM team. The goal is to catch PM
+feedback on doc-bearing code changes before they merge, instead of after the
+[tyk-docs sync](https://github.com/TykTechnologies/exp/actions/workflows/tyk-docs.yml)
+has already opened a docs PR (which forces a fix-regenerate-review loop).
+
+Behavior:
+
+- No touched doc-bearing path → the workflow ends silently.
+- Touched paths but identical generated output (pure refactor) → updates an
+  existing preview comment to "No documentation impact"; stays silent otherwise.
+- Generated output changed → sticky comment with the rendered docs diff
+  (truncated at 60k chars; full diff as the `docs-preview-diff` artifact) and a
+  one-time advisory review request to `pm_team`.
+- Fork PRs are skipped (secrets unavailable to forks).
+- Never make this a required check — it is advisory by design.
+
+Inputs:
+
+- `component` (required): `gateway`, `dashboard`, `pump`, `mdcb` or `portal` —
+  selects the generator set, mirroring the tyk-docs sync jobs.
+- `docs_paths` (required): newline-separated globs of doc-bearing paths,
+  matched against the PR's changed files.
+- `pm_team` (optional): GitHub team slug to request as advisory reviewer.
+- `comment_marker` (optional): sticky-comment identity marker.
+
+Secrets: `PROBE_APP_ID`, `PROBE_APP_PRIVATE_KEY` (org-wide App; used for the
+private `tyk-config-info-generator` checkout and the team review request).
+
+Example usage (tyk):
+
+```yaml
+name: Docs preview
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  docs-preview:
+    uses: TykTechnologies/github-actions/.github/workflows/docs-preview.yml@main
+    with:
+      component: gateway
+      docs_paths: |
+        apidef/oas/**
+        config/**
+        swagger.yml
+      pm_team: product-managers
+    secrets: inherit
+```
+
+Generation logic intentionally mirrors exp's `tyk-docs.yml`; if you change
+one, change the other (until both consume shared composite actions).
+
+Source: [/.github/workflows/docs-preview.yml](/.github/workflows/docs-preview.yml)
+
+## Gromit Drift Check
+
+Undocumented action.
+
+Source: [/.github/workflows/drift-check.yml](/.github/workflows/drift-check.yml)
+
+## Force Merge PR (Reusable)
+
+Undocumented action.
+
+Source: [/.github/workflows/force-merge.yaml](/.github/workflows/force-merge.yaml)
 
 ## Print Go API Changes
 
@@ -173,6 +262,53 @@ Source: [/.github/workflows/govulncheck.yaml](/.github/workflows/govulncheck.yam
 
 ## JIRA linter
 
+Validates pull requests against Jira tickets. Extracts Jira issue IDs from branch names or PR titles, fetches issue 
+details from Jira, updates PR descriptions with ticket information, and validates issue status.
+
+### Features
+
+- Extracts Jira issue IDs from branch names (e.g., `feature/ABC-123-description`)
+- Validates PR title contains matching Jira ticket ID
+- Fetches Jira issue details via API
+- Updates PR description with ticket details (status, summary, link)
+- Validates issue status against accepted statuses
+- Posts sticky PR comment on failure with error details
+
+### Usage as a reusable workflow
+
+```yaml
+jobs:
+  jira-lint:
+    uses: TykTechnologies/github-actions/.github/workflows/jira-lint.yaml@main
+    secrets:
+      JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+      JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
+```
+
+### Usage as a composite action
+
+```yaml
+jobs:
+  jira-lint:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: TykTechnologies/github-actions/jira-linter@main
+        with:
+          jira-base-url: 'https://tyktech.atlassian.net'
+          jira-user-email: ${{ secrets.JIRA_USER_EMAIL }}
+          jira-api-token: ${{ secrets.JIRA_TOKEN }}
+```
+
+### Secrets
+
+| Secret            | Description                              |
+|-------------------|------------------------------------------|
+| `JIRA_USER_EMAIL` | Email associated with the Jira API token |
+| `JIRA_TOKEN`      | Jira API token for authentication        |
+
 Adoption: Gateway, Dashboard.
 
 Source: [/.github/workflows/jira-lint.yaml](/.github/workflows/jira-lint.yaml)
@@ -204,6 +340,12 @@ jobs:
 
 Source: [/.github/workflows/nancy.yaml](/.github/workflows/nancy.yaml)
 
+## Path-Based OSV Scan
+
+Undocumented action.
+
+Source: [/.github/workflows/osv-path-scan.yml](/.github/workflows/osv-path-scan.yml)
+
 ## OWASP scanner
 
 Example usage:
@@ -232,11 +374,45 @@ jobs:
     uses: TykTechnologies/github-actions/.github/workflows/release-bot.yaml@main
 ```
 
-## PR Agent
+Source: [/.github/workflows/release-bot.yaml](/.github/workflows/release-bot.yaml)
 
-Undocumented action.
+## Sentinel One CNS Scans
 
-Source: [/.github/workflows/pr-agent.yaml](/.github/workflows/pr-agent.yaml)
+This runs the S1 scans and publishes the results to the S1 console.
+It has three available scanners.
+- Secret scanner
+- IaC scanner
+- Vulnerability scanner
+
+By default, all three are enabled, but it could be controlled by setting the flags appropriately
+while calling the workflow.
+Also, keep in mind that the secret scanner runs only on pull request events, as the scanner only supports
+publishing results on pull requsts.
+
+Example usage:
+
+```yaml
+name: SentinelOne CNS Scan
+
+on:
+  pull_request:
+    types: [ opened, reopened, synchronize ]
+    branches: [ master ]
+
+jobs:
+  s1_scanner:
+    uses: TykTechnologies/github-actions/.github/workflows/s1-cns-scan.yml@main
+    with:
+      iac_enabled: false
+      tag: service:vulnscan
+      scope_type: ACCOUNT
+    secrets:
+      S1_API_TOKEN: ${{ secrets.S1_API_TOKEN }}
+      CONSOLE_URL: ${{ secrets.S1_CONSOLE_URL }}
+      SCOPE_ID: ${{ secrets.S1_SCOPE_ID }}
+```
+
+Source: [/.github/workflows/s1-cns-scan.yml](/.github/workflows/s1-cns-scan.yml)
 
 ## SBOM - source bill of materials (dev)
 
@@ -308,40 +484,15 @@ jobs:
 
 Source: [/.github/workflows/sonarcloud.yaml](/.github/workflows/sonarcloud.yaml)
 
-## Sentinel One CNS Scans
+## Upgrade Tests
 
-This runs the S1 scans and publishes the results to the S1 console.
-It has three available scanners.
-- Secret scanner
-- IaC scanner
-- Vulnerability scanner
+Undocumented action.
 
-By default, all three are enabled, but it could be controlled by setting the flags appropriately
-while calling the workflow.
-Also, keep in mind that the secret scanner runs only on pull request events, as the scanner only supports
-publishing results on pull requsts.
+Source: [/.github/workflows/upgrade-tests.yml](/.github/workflows/upgrade-tests.yml)
 
-Example usage:
+## Visor
 
-```yaml
-name: SentinelOne CNS Scan
+Undocumented action.
 
-on:
-  pull_request:
-    types: [ opened, reopened, synchronize ]
-    branches: [ master ]
+Source: [/.github/workflows/visor.yaml](/.github/workflows/visor.yaml)
 
-jobs:
-  s1_scanner:
-    uses: TykTechnologies/github-actions/.github/workflows/s1-cns-scan.yml@main
-    with:
-      iac_enabled: false
-      tag: service:vulnscan
-      scope_type: ACCOUNT
-    secrets:
-      S1_API_TOKEN: ${{ secrets.S1_API_TOKEN }}
-      CONSOLE_URL: ${{ secrets.S1_CONSOLE_URL }}
-      SCOPE_ID: ${{ secrets.S1_SCOPE_ID }}
-```
-
-Source: [/.github/workflows/s1-cns-scan.yml](/.github/workflows/s1-cns-scan.yml)

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ jobs:
         apidef/oas/**
         config/**
         swagger.yml
-      pm_team: product-managers
+      pm_team: pms
     secrets: inherit
 ```
 

--- a/docs/workflows/docs-preview.md
+++ b/docs/workflows/docs-preview.md
@@ -1,0 +1,56 @@
+## Docs preview
+
+Renders the generated-documentation diff (config docs, OAS/x-tyk-gateway,
+swagger) for a PR in a source repo, posts it as a sticky PR comment, and
+requests an **advisory** review from a PM team. The goal is to catch PM
+feedback on doc-bearing code changes before they merge, instead of after the
+[tyk-docs sync](https://github.com/TykTechnologies/exp/actions/workflows/tyk-docs.yml)
+has already opened a docs PR (which forces a fix-regenerate-review loop).
+
+Behavior:
+
+- No touched doc-bearing path → the workflow ends silently.
+- Touched paths but identical generated output (pure refactor) → updates an
+  existing preview comment to "No documentation impact"; stays silent otherwise.
+- Generated output changed → sticky comment with the rendered docs diff
+  (truncated at 60k chars; full diff as the `docs-preview-diff` artifact) and a
+  one-time advisory review request to `pm_team`.
+- Fork PRs are skipped (secrets unavailable to forks).
+- Never make this a required check — it is advisory by design.
+
+Inputs:
+
+- `component` (required): `gateway`, `dashboard`, `pump`, `mdcb` or `portal` —
+  selects the generator set, mirroring the tyk-docs sync jobs.
+- `docs_paths` (required): newline-separated globs of doc-bearing paths,
+  matched against the PR's changed files.
+- `pm_team` (optional): GitHub team slug to request as advisory reviewer.
+- `comment_marker` (optional): sticky-comment identity marker.
+
+Secrets: `PROBE_APP_ID`, `PROBE_APP_PRIVATE_KEY` (org-wide App; used for the
+private `tyk-config-info-generator` checkout and the team review request).
+
+Example usage (tyk):
+
+```yaml
+name: Docs preview
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  docs-preview:
+    uses: TykTechnologies/github-actions/.github/workflows/docs-preview.yml@main
+    with:
+      component: gateway
+      docs_paths: |
+        apidef/oas/**
+        config/**
+        swagger.yml
+      pm_team: product-managers
+    secrets: inherit
+```
+
+Generation logic intentionally mirrors exp's `tyk-docs.yml`; if you change
+one, change the other (until both consume shared composite actions).

--- a/docs/workflows/docs-preview.md
+++ b/docs/workflows/docs-preview.md
@@ -48,7 +48,7 @@ jobs:
         apidef/oas/**
         config/**
         swagger.yml
-      pm_team: product-managers
+      pm_team: pms
     secrets: inherit
 ```
 

--- a/docs/workflows/release-bot.md
+++ b/docs/workflows/release-bot.md
@@ -1,0 +1,13 @@
+## Release bot
+
+```
+name: Release bot
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  release_bot:
+    uses: TykTechnologies/github-actions/.github/workflows/release-bot.yaml@main
+```

--- a/docs/workflows/s1-cns-scan.md
+++ b/docs/workflows/s1-cns-scan.md
@@ -1,0 +1,35 @@
+## Sentinel One CNS Scans
+
+This runs the S1 scans and publishes the results to the S1 console.
+It has three available scanners.
+- Secret scanner
+- IaC scanner
+- Vulnerability scanner
+
+By default, all three are enabled, but it could be controlled by setting the flags appropriately
+while calling the workflow.
+Also, keep in mind that the secret scanner runs only on pull request events, as the scanner only supports
+publishing results on pull requsts.
+
+Example usage:
+
+```yaml
+name: SentinelOne CNS Scan
+
+on:
+  pull_request:
+    types: [ opened, reopened, synchronize ]
+    branches: [ master ]
+
+jobs:
+  s1_scanner:
+    uses: TykTechnologies/github-actions/.github/workflows/s1-cns-scan.yml@main
+    with:
+      iac_enabled: false
+      tag: service:vulnscan
+      scope_type: ACCOUNT
+    secrets:
+      S1_API_TOKEN: ${{ secrets.S1_API_TOKEN }}
+      CONSOLE_URL: ${{ secrets.S1_CONSOLE_URL }}
+      SCOPE_ID: ${{ secrets.S1_SCOPE_ID }}
+```


### PR DESCRIPTION
## Jira Ticket

<!-- Paste the link to the Jira ticket below -->

[TT-XXXXX](https://tyktech.atlassian.net/browse/TT-XXXXX)

## Description

Adds a reusable **`docs-preview`** workflow that catches PM feedback on generated documentation **at the source-code PR**, before the docs are ever synced.

Today, config docs and OAS/API-spec docs in `tyk-docs` are generated from source repos (Go doc comments, `apidef/oas` annotations, swagger files) by the [exp `tyk-docs.yml` sync](https://github.com/TykTechnologies/exp/actions/workflows/tyk-docs.yml). PMs only see the content once it lands in the generated `tyk-docs` PR — and since that content can't be edited there, every PM correction means fixing the source repo, re-running the sync, and re-reviewing a new PR.

This workflow closes that loop early: on a PR in a source repo that touches doc-bearing paths, it runs the same generators as the sync against the PR's base and head, and if the rendered output differs, posts the docs diff as a sticky PR comment and requests an **advisory** review from a configurable PM team. Merges are never blocked, and PMs are never pinged when a change has no documentation impact.

Behavior summary:

- PR doesn't touch configured `docs_paths` → workflow ends silently.
- Touches them but generated output is identical (pure refactor) → existing preview comment flips to "No documentation impact"; otherwise stays silent.
- Generated output changed → sticky comment with the rendered docs diff (truncated at 60k chars; full diff uploaded as the `docs-preview-diff` artifact) plus a one-time advisory review request to `pm_team`.
- Fork PRs are skipped (secrets unavailable; the config generator resolves remote branch names).

Consumer usage (per repo, with repo-specific paths):

```yaml
jobs:
  docs-preview:
    uses: TykTechnologies/github-actions/.github/workflows/docs-preview.yml@main
    with:
      component: gateway  # gateway | dashboard | pump | mdcb | portal
      docs_paths: |
        apidef/oas/**
        config/**
        swagger.yml
      pm_team: <pm-team-slug>
    secrets: inherit
```

Generation steps (schema-gen flags, swagger Mintlify massage, `tyk-config-info-generator` invocation, OAS duplicate cleanup) are copied **verbatim** from exp's `tyk-docs.yml` so the preview matches what the sync will later produce. Factoring both into shared composite actions is a planned follow-up.

## Type of Change

- [ ] Bug fix
- [x] New feature / action
- [ ] Refactor / improvement
- [x] Documentation update
- [x] CI/CD / workflow change
- [ ] Other (please describe):

## Changes Made

- Add `.github/workflows/docs-preview.yml` reusable workflow (`workflow_call`) with two jobs:
  - `detect`: matches PR-changed files against the `docs_paths` globs; skips fork PRs.
  - `preview`: generates docs for base and head per `component` (gateway/dashboard/pump/mdcb/portal), diffs them, uploads the full diff artifact, posts/updates a marker-identified sticky comment, and requests the `pm_team` review once per PR via the PROBE GitHub App token.
- Add `docs/workflows/docs-preview.md` (README source documentation).
- Regenerate `README.md` via `task gen`. The README was stale, so the diff also picks up "Undocumented action" stubs for workflows added since the last regeneration, and drops `Github to slack` / `PR Agent`, whose source files no longer exist.
- Add `docs/workflows/s1-cns-scan.md` and `docs/workflows/release-bot.md`: these sections had been hand-edited into README only, so regeneration was silently deleting them — their content is now preserved in the `docs/` source of truth.
- Add adoption caller snippets and a rollout runbook for the five target repos (tyk, tyk-analytics, tyk-pump, tyk-sink, portal) under `docs/superpowers/plans/2026-07-21-docs-preview-adoption/`.

## Testing

- Glob matcher (detect job logic) validated with a 7-case local bash harness: nested paths, exact filenames, prefix collisions (`config.go` vs `config/**`), empty input, multi-file PRs.
- Comment-body builder validated with a 9-case local harness: sticky marker, team cc present/absent, 60k truncation with artifact link, and diffs containing triple backticks (4-backtick fence).
- `task lint` (yamllint + README regeneration) passes; docs lint reports no missing documentation for the new workflow.
- [ ] Manually triggered the affected workflow(s) and verified expected behaviour — pending pilot: a draft PR in `tyk` with the caller pinned to this branch (runbook step 2) exercising the three scenarios (docs diff + one-time PM request / "no documentation impact" flip / silent skip).
- [x] Checked that existing workflows are not broken (no existing workflow modified; README changes are generator output).

## Checklist

- [x] My changes follow the existing conventions in this repo
- [x] I have updated relevant documentation (e.g. `README.md`, action `description` fields)
- [ ] For changed shell scripts (if applicable): I ran `shellcheck`, used an appropriate shebang and error handling, and preserved required executable permissions (n/a — shell logic is inline in workflow YAML; validated via local bash test harnesses instead)
- [ ] For changed actions/scripts (if applicable): I added or updated validation, tests, or clear manual verification steps
- [ ] For changed JavaScript files (if applicable): I ran the relevant tests and linting/formatting checks
- [ ] For changed Python files (if applicable): I ran the relevant tests and linting/formatting checks
- [ ] For Dockerfile changes (if applicable): I reviewed the base image, build context, image size, and runtime security
- [ ] For changed actions (if applicable): I updated the `action.yml` interface, defaults, outputs, and examples as needed
- [x] I reviewed security implications, including least-privilege permissions and safe handling of inputs, secrets, and tokens (if applicable)
- [x] For workflow changes (if applicable): I reviewed triggers, permissions, concurrency, and fork safety
- [ ] I have assigned a reviewer

<!-- Notes for reviewers:
- Permissions: workflow-level `contents: read`, `pull-requests: write`; the PROBE App token is used only for the private tyk-config-info-generator checkout and the team review request (GITHUB_TOKEN cannot request org team reviews).
- Fork safety: detect job hard-skips PRs from forks.
- This check must NEVER be added to required checks — it is advisory by design.
- Open items before rollout (marked CONFIRM in the adoption snippets): real PM team slug, pump config path, portal swagger source paths.
-->
