### PR TITLE
[TT-17509]: Update s1 cns cli to the latest 1.0.4 version.

### DIFF
--- a/.github/workflows/s1-cns-scan.yml
+++ b/.github/workflows/s1-cns-scan.yml
@@ -3,9 +3,9 @@ name: SentinelOne CNS Scan
 on:
   workflow_call:
     inputs:
-      tag:
-        description: 'The tag configured for the scan policy in S1 Console'
-        default: "scan:tykchecks"
+      policy_id:
+        description: 'The S1 scan policy'
+        default: ""
         type: string
       scope_type:
         description: 'The scope in which the scan policy is configured'
@@ -60,13 +60,13 @@ jobs:
           fetch-depth: 0
 
       - name: Configure SentinelOne Shift Left CLI
-        run: s1-cns-cli config --service-user-api-token "$S1_TOKEN" --management-console-url "$CONSOLE_URL" --scope-type "$SCOPE_TYPE" --scope-id "$SCOPE_ID" --tag "$TAG"
+        run: s1-cns-cli config --service-user-api-token "$S1_TOKEN" --management-console-url "$CONSOLE_URL" --scope-type "$SCOPE_TYPE" --scope-id "$SCOPE_ID" --policy-id "$POLICY_ID"
         env:
           S1_TOKEN: ${{ secrets.S1_API_TOKEN  }}
           CONSOLE_URL: ${{ secrets.CONSOLE_URL }}
           SCOPE_TYPE: ${{ inputs.scope_type }}
           SCOPE_ID: ${{ secrets.SCOPE_ID }}
-          TAG: ${{ inputs.tag }}
+          POLICY_ID: ${{ inputs.policy_id }}
 
 
       - name: Configure git config
@@ -77,6 +77,7 @@ jobs:
         # only available on pull requests.
         if: github.event_name  == 'pull_request' && inputs.secrets_enabled
         id: secret-detector
+        continue-on-error: true
         run: s1-cns-cli scan secret -d "$PWD" --pull-request "$SRC" "$DEST" --repo-full-name "$REPO_FULL_NAME"  --repo-url "$REPO_URL/$REPO_FULL_NAME" --provider GITHUB --publish-result
         env:
           DEST: ${{ github.event.pull_request.base.sha }}
@@ -84,6 +85,7 @@ jobs:
 
       - name: Run IaC Scanner
         if: inputs.iac_enabled
+        continue-on-error: true
         run: s1-cns-cli scan iac -d "$PWD" --repo-full-name "$REPO_FULL_NAME"  --repo-url "$REPO_URL/$REPO_FULL_NAME" --branch "$BRANCH" --provider GITHUB --publish-result
         id: iac-scanner
         env:
@@ -92,6 +94,11 @@ jobs:
       - name: Run Vulnerability Scanner
         if: inputs.vuln_enabled
         id: vuln-scanner
-        run: s1-cns-cli scan vuln --repo-full-name "$REPO_FULL_NAME" ${{ inputs.skip_paths != '' && '--skip-paths "$SKIP_PATHS"' || '' }} -d "$PWD"
+        continue-on-error: true
+        run: s1-cns-cli scan vuln --repo-full-name "$REPO_FULL_NAME" ${{ inputs.skip_paths != '' && '--skip-paths "$SKIP_PATHS"' || '' }} -d "$PWD" --publish-result
         env:
           SKIP_PATHS: ${{ inputs.skip_paths }}
+
+      - name: Check for failures
+        if: steps.secret-detector.outcome == 'failure' || steps.iac-scanner.outcome == 'failure' || steps.vuln-scanner.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/s1-cns-scan.yml
+++ b/.github/workflows/s1-cns-scan.yml
@@ -99,7 +99,12 @@ jobs:
         if: inputs.vuln_enabled
         id: vuln-scanner
         continue-on-error: true
-        run: s1-cns-cli scan vuln --repo-full-name "$REPO_FULL_NAME"  --repo-url "$REPO_URL/$REPO_FULL_NAME" --provider GITHUB --repository-type organization  ${{ inputs.skip_paths != '' && '--skip-paths "$SKIP_PATHS"' || '' }} -d "$PWD" --publish-result
+        run: |
+          args=(--repo-full-name "$REPO_FULL_NAME" --repo-url "$REPO_URL/$REPO_FULL_NAME" --provider GITHUB --repository-type organization)
+          if [ -n "$SKIP_PATHS" ]; then
+            args+=(--skip-paths "$SKIP_PATHS")
+          fi
+          s1-cns-cli scan vuln "${args[@]}" -d "$PWD" --publish-result
         env:
           SKIP_PATHS: ${{ inputs.skip_paths }}
 

--- a/.github/workflows/s1-cns-scan.yml
+++ b/.github/workflows/s1-cns-scan.yml
@@ -5,8 +5,8 @@ on:
     inputs:
       policy_id:
         description: 'The S1 scan policy'
-        default: ""
         type: string
+        required: true
       scope_type:
         description: 'The scope in which the scan policy is configured'
         default: "ACCOUNT"
@@ -20,12 +20,16 @@ on:
         default: true
         type: boolean
       vuln_enabled:
-        description: 'Whether vulnerability scannin should be enabled'
+        description: 'Whether vulnerability scanning should be enabled'
         default: true
         type: boolean
       skip_paths:
         description: 'Provide a space separated list of paths that need to be skipped during vulnerablity scanning'
         type: string
+      vuln_fail:
+        description: 'Fail the workflow if vulnerabilities are detected, default is false'
+        type: boolean
+        default: false
     secrets:
       S1_API_TOKEN:
         description: 'S1 API Token configured for scanning'
@@ -100,5 +104,5 @@ jobs:
           SKIP_PATHS: ${{ inputs.skip_paths }}
 
       - name: Check for failures
-        if: steps.secret-detector.outcome == 'failure' || steps.iac-scanner.outcome == 'failure' || steps.vuln-scanner.outcome == 'failure'
+        if: (steps.secret-detector.outcome == 'failure' || steps.iac-scanner.outcome == 'failure') || ( steps.vuln-scanner.outcome == 'failure' && inputs.vuln_fail == true )
         run: exit 1

--- a/.github/workflows/s1-cns-scan.yml
+++ b/.github/workflows/s1-cns-scan.yml
@@ -95,7 +95,7 @@ jobs:
         if: inputs.vuln_enabled
         id: vuln-scanner
         continue-on-error: true
-        run: s1-cns-cli scan vuln --repo-full-name "$REPO_FULL_NAME" ${{ inputs.skip_paths != '' && '--skip-paths "$SKIP_PATHS"' || '' }} -d "$PWD" --publish-result
+        run: s1-cns-cli scan vuln --repo-full-name "$REPO_FULL_NAME"  --repo-url "$REPO_URL/$REPO_FULL_NAME" --provider GITHUB --repository-type organization  ${{ inputs.skip_paths != '' && '--skip-paths "$SKIP_PATHS"' || '' }} -d "$PWD" --publish-result
         env:
           SKIP_PATHS: ${{ inputs.skip_paths }}
 

--- a/.github/workflows/s1-cns-scan.yml
+++ b/.github/workflows/s1-cns-scan.yml
@@ -41,9 +41,9 @@ jobs:
   s1-shift-left-cli:
     runs-on: ubuntu-latest
     container:
-      # latest version v0.5.4 - update digest after checking the image when
+      # latest version v1.0.4 - update digest after checking the image when
       # new version comes out.
-      image: pingsafe/s1-shift-left-cli@sha256:acd49cfd5ad72d488daf4e2418bd56891fbdef4d5da4729ccdafd6b9bbc5c8ad
+      image: pingsafe/s1-shift-left-cli@sha256:1bceb426867bd3389fcff6174d06e6bfee23f029903d8d006a52444e12867c06
       options: --entrypoint ""
     permissions:
       contents: read


### PR DESCRIPTION
## Jira Ticket

<!-- Paste the link to the Jira ticket below -->

[TT-17509](https://tyktech.atlassian.net/browse/TT-17509)

## Description

- Updates the sentinel one docker image hash to use the latest version.
- The latest version has some breaking changes, and this fixes it too, by switching from scan tags to policy id for scans.
- S1 has now also added the capability to publish vulnerability scan results to S1 console, and this is enabled as well.
- Do not fail on finding vulnerabilities. Earlier behaviour was to fail the workflow if vulnerabilities were found, based on the upstream policy on S1. Now we do not fail by default, as failing the workflow doesn't achieve anything, apart from having an undesired red on the workflow status.

## Type of Change

- [x] Version bump

## Changes Made


## Testing

<!-- Describe how you tested these changes. Include relevant workflow run links if applicable. -->

- [X] Manually triggered the affected workflow(s) and verified expected behaviour
    https://github.com/TykTechnologies/tyk-analytics/actions/runs/31079849361
- [ ] Checked that existing workflows are not broken 





[TT-17509]: https://tyktech.atlassian.net/browse/TT-17509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ