### PR TITLE
TT-17874: timeout docker-compose log collection in reporting action

### DIFF
--- a/.github/actions/tests/reporting/action.yaml
+++ b/.github/actions/tests/reporting/action.yaml
@@ -49,7 +49,13 @@ runs:
         pull_policy: 'if_not_present'
         ECR: ${{ steps.ecr.outputs.registry }}
       run: |
-        docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile all logs | sort > ${{ github.workspace }}/docker-compose.log
+        # Cap log collection: `docker compose logs` can hang if a container is
+        # unresponsive, which otherwise runs the job to its full timeout. `timeout`
+        # kills it after 5m; a miss just means slightly truncated diagnostic logs.
+        # (Composite-action steps can't take timeout-minutes, so we bound the cmd.)
+        timeout 300 docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile all logs > ${{ github.workspace }}/docker-compose.raw.log 2>&1 \
+          || echo "::warning::docker compose logs did not complete within 300s; logs may be truncated"
+        sort ${{ github.workspace }}/docker-compose.raw.log > ${{ github.workspace }}/docker-compose.log
         echo "::group::DockerLogs"
         cat ${{ github.workspace }}/docker-compose.log
         echo "::endgroup::"


### PR DESCRIPTION
## What

Bounds the log-collection step in the shared `tests/reporting` action with a `timeout`.

The **"Docker logs for all components"** step runs `docker compose … logs`, which can **hang** if a container is unresponsive — running the calling test job to its full timeout (e.g. 45 min) just to collect diagnostics. This wraps it in `timeout 300` so it's capped at 5 min, emits a `::warning::` on miss, and stays best-effort (a slow/failed log dump never fails the job).

`timeout-minutes` isn't supported on composite-action steps, so the command itself is bounded. The action is shared, so this covers **both API and UI** test reporting.

Part of TT-17874 (release-pipeline speed-up). Companion PRs: gromit templates (TykTechnologies/gromit#521), tyk-analytics test fixes (TykTechnologies/tyk-analytics#6047).

[TT-17874](https://tyktech.atlassian.net/browse/TT-17874)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[TT-17874]: https://tyktech.atlassian.net/browse/TT-17874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ