### PR TITLE
TT-17868 fix drift-check GOPROXY cache

### DIFF
--- a/.github/actions/tests/env-up/action.yaml
+++ b/.github/actions/tests/env-up/action.yaml
@@ -103,7 +103,10 @@ runs:
         cat versions.env local.env
         echo "::endgroup::"
         # bring up env, the project name is important
-        docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile master-datacenter up --quiet-pull -d --wait --wait-timeout 120
+        # keycloak's own healthcheck (start_period: 30s, retries: 15 x
+        # interval: 10s) has a 180s worst case on its own — give the whole
+        # profile enough headroom to clear that.
+        docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile master-datacenter up --quiet-pull -d --wait --wait-timeout 240
         # dash-bootstrap.sh has no retry of its own (set -e on the first curl),
         # so without --wait above it could hit tyk-analytics before it's
         # actually serving, failing the whole step or leaving the org/user

--- a/.github/actions/tests/env-up/action.yaml
+++ b/.github/actions/tests/env-up/action.yaml
@@ -103,14 +103,9 @@ runs:
         cat versions.env local.env
         echo "::endgroup::"
         # bring up env, the project name is important
-        # --wait requires TykTechnologies/tyk-pro's keycloak healthcheck fix
-        # (TT-17868_fix_keycloak_healthcheck_timeout / Connection: close) --
-        # without it, keycloak's healthcheck hangs until Docker's own 10s
-        # timeout on every attempt even though keycloak itself is fully up,
-        # so --wait never returns cleanly.
-        docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile master-datacenter up --quiet-pull -d --wait
+        docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile master-datacenter up --quiet-pull -d
         ./dash-bootstrap.sh http://localhost:3000
-        docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile slave-datacenter up --quiet-pull -d --wait
+        docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile slave-datacenter up --quiet-pull -d
         echo "$(cat pytest.env | grep USER_API_SECRET)" >> $GITHUB_OUTPUT
         echo "ts=$(date +%s%N)" >> $GITHUB_OUTPUT
         echo "::group::Docker images"

--- a/.github/actions/tests/env-up/action.yaml
+++ b/.github/actions/tests/env-up/action.yaml
@@ -103,9 +103,14 @@ runs:
         cat versions.env local.env
         echo "::endgroup::"
         # bring up env, the project name is important
-        docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile master-datacenter up --quiet-pull -d
+        # --wait requires TykTechnologies/tyk-pro's keycloak healthcheck fix
+        # (TT-17868_fix_keycloak_healthcheck_timeout / Connection: close) --
+        # without it, keycloak's healthcheck hangs until Docker's own 10s
+        # timeout on every attempt even though keycloak itself is fully up,
+        # so --wait never returns cleanly.
+        docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile master-datacenter up --quiet-pull -d --wait
         ./dash-bootstrap.sh http://localhost:3000
-        docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile slave-datacenter up --quiet-pull -d
+        docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile slave-datacenter up --quiet-pull -d --wait
         echo "$(cat pytest.env | grep USER_API_SECRET)" >> $GITHUB_OUTPUT
         echo "ts=$(date +%s%N)" >> $GITHUB_OUTPUT
         echo "::group::Docker images"

--- a/.github/actions/tests/env-up/action.yaml
+++ b/.github/actions/tests/env-up/action.yaml
@@ -103,30 +103,9 @@ runs:
         cat versions.env local.env
         echo "::endgroup::"
         # bring up env, the project name is important
-        # keycloak's own healthcheck (start_period: 30s, retries: 15 x
-        # interval: 10s) has a 180s worst case on its own — give the whole
-        # profile enough headroom to clear that.
-        # DEBUG: keycloak has consistently failed this --wait on every prior
-        # run regardless of --wait-timeout (120s/240s) or runner size
-        # (8x/16x) — dump its logs on failure to find the real cause instead
-        # of continuing to guess at timeout/resource tuning.
-        docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile master-datacenter up --quiet-pull -d --wait --wait-timeout 240 || {
-          echo "::group::keycloak logs"
-          docker logs keycloak
-          echo "::endgroup::"
-          docker inspect keycloak --format '{{json .State.Health}}' || true
-          exit 1
-        }
-        # dash-bootstrap.sh has no retry of its own (set -e on the first curl),
-        # so without --wait above it could hit tyk-analytics before it's
-        # actually serving, failing the whole step or leaving the org/user
-        # bootstrap incomplete for the slave gateways started next.
+        docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile master-datacenter up --quiet-pull -d
         ./dash-bootstrap.sh http://localhost:3000
-        # slave-datacenter brings up 6 gateways (2 per mini-datacenter) each
-        # behind its own checker with retries: 30 x interval: 5s — worst case
-        # is close to 150s per service, so give this profile more headroom
-        # than the single-dashboard master-datacenter wait above.
-        docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile slave-datacenter up --quiet-pull -d --wait --wait-timeout 240
+        docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile slave-datacenter up --quiet-pull -d
         echo "$(cat pytest.env | grep USER_API_SECRET)" >> $GITHUB_OUTPUT
         echo "ts=$(date +%s%N)" >> $GITHUB_OUTPUT
         echo "::group::Docker images"

--- a/.github/actions/tests/env-up/action.yaml
+++ b/.github/actions/tests/env-up/action.yaml
@@ -103,9 +103,13 @@ runs:
         cat versions.env local.env
         echo "::endgroup::"
         # bring up env, the project name is important
-        docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile master-datacenter up --quiet-pull -d
+        docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile master-datacenter up --quiet-pull -d --wait --wait-timeout 120
+        # dash-bootstrap.sh has no retry of its own (set -e on the first curl),
+        # so without --wait above it could hit tyk-analytics before it's
+        # actually serving, failing the whole step or leaving the org/user
+        # bootstrap incomplete for the slave gateways started next.
         ./dash-bootstrap.sh http://localhost:3000
-        docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile slave-datacenter up --quiet-pull -d
+        docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile slave-datacenter up --quiet-pull -d --wait --wait-timeout 120
         echo "$(cat pytest.env | grep USER_API_SECRET)" >> $GITHUB_OUTPUT
         echo "ts=$(date +%s%N)" >> $GITHUB_OUTPUT
         echo "::group::Docker images"

--- a/.github/actions/tests/env-up/action.yaml
+++ b/.github/actions/tests/env-up/action.yaml
@@ -106,7 +106,17 @@ runs:
         # keycloak's own healthcheck (start_period: 30s, retries: 15 x
         # interval: 10s) has a 180s worst case on its own — give the whole
         # profile enough headroom to clear that.
-        docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile master-datacenter up --quiet-pull -d --wait --wait-timeout 240
+        # DEBUG: keycloak has consistently failed this --wait on every prior
+        # run regardless of --wait-timeout (120s/240s) or runner size
+        # (8x/16x) — dump its logs on failure to find the real cause instead
+        # of continuing to guess at timeout/resource tuning.
+        docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile master-datacenter up --quiet-pull -d --wait --wait-timeout 240 || {
+          echo "::group::keycloak logs"
+          docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml logs keycloak
+          echo "::endgroup::"
+          docker inspect keycloak --format '{{json .State.Health}}' || true
+          exit 1
+        }
         # dash-bootstrap.sh has no retry of its own (set -e on the first curl),
         # so without --wait above it could hit tyk-analytics before it's
         # actually serving, failing the whole step or leaving the org/user

--- a/.github/actions/tests/env-up/action.yaml
+++ b/.github/actions/tests/env-up/action.yaml
@@ -112,7 +112,7 @@ runs:
         # of continuing to guess at timeout/resource tuning.
         docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile master-datacenter up --quiet-pull -d --wait --wait-timeout 240 || {
           echo "::group::keycloak logs"
-          docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml logs keycloak
+          docker logs keycloak
           echo "::endgroup::"
           docker inspect keycloak --format '{{json .State.Health}}' || true
           exit 1

--- a/.github/actions/tests/env-up/action.yaml
+++ b/.github/actions/tests/env-up/action.yaml
@@ -109,7 +109,11 @@ runs:
         # actually serving, failing the whole step or leaving the org/user
         # bootstrap incomplete for the slave gateways started next.
         ./dash-bootstrap.sh http://localhost:3000
-        docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile slave-datacenter up --quiet-pull -d --wait --wait-timeout 120
+        # slave-datacenter brings up 6 gateways (2 per mini-datacenter) each
+        # behind its own checker with retries: 30 x interval: 5s — worst case
+        # is close to 150s per service, so give this profile more headroom
+        # than the single-dashboard master-datacenter wait above.
+        docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile slave-datacenter up --quiet-pull -d --wait --wait-timeout 240
         echo "$(cat pytest.env | grep USER_API_SECRET)" >> $GITHUB_OUTPUT
         echo "ts=$(date +%s%N)" >> $GITHUB_OUTPUT
         echo "::group::Docker images"

--- a/.github/workflows/drift-check.yml
+++ b/.github/workflows/drift-check.yml
@@ -37,6 +37,13 @@ jobs:
 
       - name: Build gromit from master
         if: ${{ !contains(github.event.pull_request.labels.*.name, inputs.label_name) }}
+        # GOPROXY=direct bypasses proxy.golang.org's CDN, which caches the
+        # @master ref's resolved commit for 30 minutes (Cache-Control:
+        # max-age=1800). Without this, a merge to gromit's master can take
+        # up to half an hour to be picked up here, making this check flag
+        # false drift against a stale render.
+        env:
+          GOPROXY: direct
         run: go install github.com/TykTechnologies/gromit@master
 
       - name: Check for drift from gromit


### PR DESCRIPTION
## Summary
- **drift-check**: `GOPROXY=direct` bypasses proxy.golang.org's CDN cache for the `@master` ref (30 min TTL), so a merge to gromit's master is picked up immediately instead of up to half an hour later.

## Why
Confirmed via repeated CI runs pulling a stale gromit version (e.g. an old commit instead of a just-merged one) up to 20+ minutes after merge, matching proxy.golang.org's `Cache-Control: public, max-age=1800` header on the `@master` ref resolution.