### PR TITLE
Tt 18073 fix caching affecting drift-check

### DIFF
--- a/.github/workflows/drift-check.yml
+++ b/.github/workflows/drift-check.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Build gromit from master
         if: ${{ !contains(github.event.pull_request.labels.*.name, inputs.label_name) }}
+        env:
+          GOPROXY: direct
         run: go install github.com/TykTechnologies/gromit@master
 
       - name: Check for drift from gromit

--- a/jira-linter/cmd/linter/main.go
+++ b/jira-linter/cmd/linter/main.go
@@ -98,8 +98,37 @@ func run() error {
 	return nil
 }
 
+// isBranchWithoutTicketID checks if a branch name is a known pattern that doesn't contain a Jira ticket ID
+func isBranchWithoutTicketID(branchName string) bool {
+	// Gromit creates branches like: releng/master, releng/release-X.Y, etc.
+	// Skip ticket extraction for these patterns
+	ignoredPatterns := []string{
+		"releng/",           // Releng branches (release management)
+		"dependabot/",       // Dependabot-created branches
+		"renovate/",         // Renovate-created branches
+		"snyk-",             // Snyk-created branches
+	}
+
+	for _, pattern := range ignoredPatterns {
+		if strings.HasPrefix(strings.ToLower(branchName), pattern) {
+			return true
+		}
+	}
+	return false
+}
+
 func validateBranchAndTitle(config *Config, branchName string) (string, error) {
-	issueIDInBranch, branchErr := findIssueID(branchName)
+	// Check if branch name is a known pattern that shouldn't be searched for ticket IDs
+	branchHasNoTicket := isBranchWithoutTicketID(branchName)
+
+	var issueIDInBranch string
+	var branchErr error
+	if !branchHasNoTicket {
+		issueIDInBranch, branchErr = findIssueID(branchName)
+	} else {
+		branchErr = fmt.Errorf("branch name is a known pattern without ticket ID")
+	}
+
 	issueIDInTitle, titleErr := findIssueID(config.PR.Title)
 
 	switch {

--- a/jira-linter/cmd/linter/main_test.go
+++ b/jira-linter/cmd/linter/main_test.go
@@ -39,6 +39,38 @@ func TestFindIssueID(t *testing.T) {
 	}
 }
 
+func TestIsBranchWithoutTicketID(t *testing.T) {
+	tests := []struct {
+		name       string
+		branchName string
+		want       bool
+	}{
+		// Gromit branches - should skip
+		{"releng/master", "releng/master", true},
+		{"releng/release-5.13", "releng/release-5.13", true},
+		{"releng/release-5.13-go126", "releng/release-5.13-go126", true},
+		// Automation branches - should skip
+		{"dependabot", "dependabot/npm/lodash", true},
+		{"renovate", "renovate/docker-digest", true},
+		{"snyk", "snyk-something", true},
+		// Regular branches with tickets - should NOT skip
+		{"feat with ticket", "feat/TT-12345/new-feature", false},
+		{"bugfix with ticket", "bugfix/ABC-999", false},
+		// Regular branches without tickets - should NOT skip
+		{"feature branch", "feature/my-branch", false},
+		{"main", "main", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isBranchWithoutTicketID(tt.branchName)
+			if got != tt.want {
+				t.Errorf("isBranchWithoutTicketID(%q) = %v, want %v", tt.branchName, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestValidateBranchAndTitle(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -67,6 +99,20 @@ func TestValidateBranchAndTitle(t *testing.T) {
 			"Add new feature",
 			"",
 			true,
+		},
+		{
+			"releng branch with ticket in title",
+			"releng/release-5.13-go126",
+			"TT-17868: Fix jira linter false positives",
+			"TT-17868",
+			false,
+		},
+		{
+			"dependabot branch with ticket in title",
+			"dependabot/npm/lodash",
+			"ABC-123: Update dependency",
+			"ABC-123",
+			false,
 		},
 	}
 


### PR DESCRIPTION
## Jira Ticket

<!-- Paste the link to the Jira ticket below -->

[TT-18073](https://tyktech.atlassian.net/browse/TT-18073)

## Description

<!-- Briefly describe what this PR does and why. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature / action
- [x] Refactor / improvement
- [ ] Documentation update
- [ ] CI/CD / workflow change
- [ ] Other (please describe):

## Changes Made

<!-- List the key changes introduced by this PR. -->

-
-

## Testing

<!-- Describe how you tested these changes. Include relevant workflow run links if applicable. -->

- [ ] Manually triggered the affected workflow(s) and verified expected behaviour
- [ ] Checked that existing workflows are not broken

## Checklist

- [x] My changes follow the existing conventions in this repo
- [ ] I have updated relevant documentation (e.g. `README.md`, action `description` fields)
- [ ] For changed shell scripts (if applicable): I ran `shellcheck`, used an appropriate shebang and error handling, and preserved required executable permissions
- [ ] For changed actions/scripts (if applicable): I added or updated validation, tests, or clear manual verification steps
- [ ] For changed JavaScript files (if applicable): I ran the relevant tests and linting/formatting checks
- [ ] For changed Python files (if applicable): I ran the relevant tests and linting/formatting checks
- [ ] For Dockerfile changes (if applicable): I reviewed the base image, build context, image size, and runtime security
- [ ] For changed actions (if applicable): I updated the `action.yml` interface, defaults, outputs, and examples as needed
- [ ] I reviewed security implications, including least-privilege permissions and safe handling of inputs, secrets, and tokens (if applicable)
- [ ] For workflow changes (if applicable): I reviewed triggers, permissions, concurrency, and fork safety
- [x] I have assigned a reviewer


[TT-18073]: https://tyktech.atlassian.net/browse/TT-18073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ