### PR TITLE
TT-18284: drop debian:bullseye from the upgrade-test distro matrix

### DIFF
--- a/.github/actions/tests/distro-matrix/action.yaml
+++ b/.github/actions/tests/distro-matrix/action.yaml
@@ -19,7 +19,7 @@ runs:
       id: params
       run: |
         echo 'deb<<EOF' >> $GITHUB_OUTPUT
-        echo '["debian:bullseye","ubuntu:focal","ubuntu:jammy","debian:bookworm","debian:trixie","ubuntu:noble","ubuntu:26.04"]' >> $GITHUB_OUTPUT
+        echo '["ubuntu:focal","ubuntu:jammy","debian:bookworm","debian:trixie","ubuntu:noble","ubuntu:26.04"]' >> $GITHUB_OUTPUT
         echo 'EOF' >> $GITHUB_OUTPUT
         echo 'rpm<<EOF' >> $GITHUB_OUTPUT
         echo '["registry.access.redhat.com/ubi8/ubi","amazonlinux:2023","registry.access.redhat.com/ubi9/ubi","registry.access.redhat.com/ubi10/ubi","rockylinux:9"]' >> $GITHUB_OUTPUT


### PR DESCRIPTION
Fixes [TT-18284](https://tyktech.atlassian.net/browse/TT-18284).

## Why

Debian 11 reached end of LTS and its security `Release` file expired on 2026-09-07:

```
E: Release file for http://deb.debian.org/debian-security/dists/bullseye-security/InRelease
   is expired (invalid since 1d 12h 37min 24s)
```

`apt-get update` now exits 100 inside `debian:bullseye` **before any Tyk package is
installed**, so the `upgrade-deb` leg fails for every gromit-managed repo. Observed
today on tyk-pump, tyk-sink, portal and tyk-identity-broker; tyk passed the same leg
on 2026-09-07, which brackets the expiry.

Because the matrix uses `fail-fast: true`, that single leg also **cancels the other 25
healthy distro legs**, so failures currently read as "1 failed, 14 cancelled" and tell
you nothing about the rest.

## Coverage

Debian stays covered by `debian:bookworm` (12) and `debian:trixie` (13). Nothing is
lost — this is a deletion, not a swap.

## Follow-ups, deliberately not in this PR

- **`fail-fast: false`** on the three matrices in `upgrade-tests.yml`, so one bad
  distro stops hiding the other 25. Independent of Bullseye; worth its own change.
- **`ubuntu:focal`** is in the same position — Ubuntu 20.04 standard support ended
  April 2025. Worth deciding rather than discovering.
- **`from_ver` has no default for `portal` or `tyk-identity-broker`**, so
  `upgrade-tests.yml` generates `apt-get install -y tyk-identity-broker=` and falls
  through `|| echo "Previous version not found, testing fresh install"`. Those two
  repos' upgrade tests have never tested an upgrade and pass green. Needs a product
  decision on baseline versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TT-18284]: https://tyktech.atlassian.net/browse/TT-18284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ